### PR TITLE
feat: add POST /todos endpoint with in-memory storage

### DIFF
--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -1,8 +1,41 @@
+from datetime import datetime, timezone
+
 from fastapi import FastAPI
+from pydantic import BaseModel, Field
 
 app = FastAPI()
+
+
+class TodoCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+
+
+class Todo(BaseModel):
+    id: int
+    title: str
+    done: bool
+    created_at: datetime
+
+
+_todos: list[Todo] = []
+
+
+def _next_id() -> int:
+    return len(_todos) + 1
 
 
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.post("/todos", status_code=201)
+def create_todo(body: TodoCreate) -> Todo:
+    todo = Todo(
+        id=_next_id(),
+        title=body.title,
+        done=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    _todos.append(todo)
+    return todo

--- a/tests/test_todos_create.py
+++ b/tests/test_todos_create.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api import app as app_module
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "_todos", [])
+
+
+def test_create_todo_returns_201_with_payload() -> None:
+    response = client.post("/todos", json={"title": "buy milk"})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] == 1
+    assert data["title"] == "buy milk"
+    assert data["done"] is False
+    datetime.fromisoformat(data["created_at"])
+
+
+def test_create_todo_assigns_incrementing_ids() -> None:
+    r1 = client.post("/todos", json={"title": "first"})
+    r2 = client.post("/todos", json={"title": "second"})
+    assert r1.json()["id"] == 1
+    assert r2.json()["id"] == 2
+
+
+def test_create_todo_rejects_missing_title() -> None:
+    response = client.post("/todos", json={})
+    assert response.status_code == 422
+
+
+def test_create_todo_rejects_empty_title() -> None:
+    response = client.post("/todos", json={"title": ""})
+    assert response.status_code == 422
+
+
+def test_create_todo_rejects_overlong_title() -> None:
+    response = client.post("/todos", json={"title": "x" * 201})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Add `POST /todos` endpoint that accepts `{"title": str}` and returns `201` with a full TODO object (`id`, `title`, `done`, `created_at`)
- Pydantic models (`TodoCreate`, `Todo`) handle validation: title required, 1–200 chars
- In-memory `_todos` list with `_next_id()` helper for monotonic IDs
- Five new tests covering 201 response, incrementing IDs, and three 422 validation cases

Closes #4

## Test plan

- [x] `test_create_todo_returns_201_with_payload` — correct status, shape, and ISO 8601 timestamp
- [x] `test_create_todo_assigns_incrementing_ids` — sequential POSTs get id 1, 2
- [x] `test_create_todo_rejects_missing_title` — 422
- [x] `test_create_todo_rejects_empty_title` — 422
- [x] `test_create_todo_rejects_overlong_title` — 422
- [x] Existing `test_health.py` (2 tests) still passes

`pytest -q` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)