### PR TITLE
ci: add pytest workflow for PR and main-push gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -e .[dev]
+      - run: pytest -q


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/test.yml` — a single `pytest` job that runs on every PR targeting `main` and every push to `main`.
- Uses `actions/checkout@v4`, `actions/setup-python@v5` (Python 3.11, pip cache), `pip install -e .[dev]`, and `pytest -q`.
- Gives the Merger a real "all checks passed" signal and arms the Fixer (which listens on `check_suite.failure`).

Closes #6

## Test plan

- [x] `pytest -q` passes locally (7 tests, 0 failures)
- [ ] After merge, `gh run list --workflow=test.yml` shows a completed run
- [ ] PRs show a `Tests / pytest` check entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)