### PR TITLE
feat: add GET /todos list and GET /todos/{id} endpoints

### DIFF
--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
 
 app = FastAPI()
@@ -15,6 +15,11 @@ class Todo(BaseModel):
     title: str
     done: bool
     created_at: datetime
+
+
+class TodoList(BaseModel):
+    items: list[Todo]
+    total: int
 
 
 _todos: list[Todo] = []
@@ -39,3 +44,21 @@ def create_todo(body: TodoCreate) -> Todo:
     )
     _todos.append(todo)
     return todo
+
+
+@app.get("/todos")
+def list_todos(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> TodoList:
+    sorted_todos = sorted(_todos, key=lambda t: t.id, reverse=True)
+    page = sorted_todos[offset : offset + limit]
+    return TodoList(items=page, total=len(_todos))
+
+
+@app.get("/todos/{todo_id}")
+def get_todo(todo_id: int) -> Todo:
+    for todo in _todos:
+        if todo.id == todo_id:
+            return todo
+    raise HTTPException(status_code=404, detail="Not Found")

--- a/tests/test_todos_read.py
+++ b/tests/test_todos_read.py
@@ -1,0 +1,95 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api import app as app_module
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "_todos", [])
+
+
+def _create_todo(title: str) -> dict:
+    return client.post("/todos", json={"title": title}).json()
+
+
+def test_list_empty_returns_zero_total() -> None:
+    response = client.get("/todos")
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0}
+
+
+def test_list_returns_total_regardless_of_pagination() -> None:
+    for i in range(5):
+        _create_todo(f"todo {i}")
+    response = client.get("/todos", params={"limit": 2})
+    data = response.json()
+    assert len(data["items"]) == 2
+    assert data["total"] == 5
+
+
+def test_list_orders_by_id_desc() -> None:
+    _create_todo("a")
+    _create_todo("b")
+    _create_todo("c")
+    response = client.get("/todos")
+    titles = [item["title"] for item in response.json()["items"]]
+    assert titles == ["c", "b", "a"]
+
+
+def test_list_default_limit_is_20() -> None:
+    for i in range(25):
+        _create_todo(f"todo {i}")
+    response = client.get("/todos")
+    data = response.json()
+    assert len(data["items"]) == 20
+    assert data["total"] == 25
+
+
+def test_list_offset_skips_items() -> None:
+    for i in range(5):
+        _create_todo(f"todo {i}")
+    response = client.get("/todos", params={"offset": 2, "limit": 10})
+    data = response.json()
+    assert len(data["items"]) == 3
+    ids = [item["id"] for item in data["items"]]
+    assert ids == [3, 2, 1]
+
+
+def test_list_rejects_limit_zero() -> None:
+    response = client.get("/todos", params={"limit": 0})
+    assert response.status_code == 422
+
+
+def test_list_rejects_limit_over_100() -> None:
+    response = client.get("/todos", params={"limit": 101})
+    assert response.status_code == 422
+
+
+def test_list_rejects_negative_offset() -> None:
+    response = client.get("/todos", params={"offset": -1})
+    assert response.status_code == 422
+
+
+def test_get_by_id_returns_item() -> None:
+    _create_todo("buy milk")
+    response = client.get("/todos/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 1
+    assert data["title"] == "buy milk"
+    assert data["done"] is False
+
+
+def test_get_by_id_returns_404_when_missing() -> None:
+    response = client.get("/todos/999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}
+
+
+def test_get_by_id_returns_422_on_non_integer() -> None:
+    response = client.get("/todos/abc")
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Add `GET /todos` with paginated response (`{items, total}`), `limit`/`offset` query params (validated), and descending `id` ordering
- Add `GET /todos/{id}` returning the todo or 404 when not found
- Add 11 new tests in `tests/test_todos_read.py` covering happy paths, pagination, ordering, and 422/404 error cases

Closes #8

## Test plan

- [x] `test_list_empty_returns_zero_total`
- [x] `test_list_returns_total_regardless_of_pagination`
- [x] `test_list_orders_by_id_desc`
- [x] `test_list_default_limit_is_20`
- [x] `test_list_offset_skips_items`
- [x] `test_list_rejects_limit_zero`
- [x] `test_list_rejects_limit_over_100`
- [x] `test_list_rejects_negative_offset`
- [x] `test_get_by_id_returns_item`
- [x] `test_get_by_id_returns_404_when_missing`
- [x] `test_get_by_id_returns_422_on_non_integer`
- [x] All 18 tests pass (`pytest -q` exits 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)