### PR TITLE
feat: add PATCH, DELETE, done filter, and stats endpoints

### DIFF
--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
 app = FastAPI()
@@ -8,6 +8,12 @@ app = FastAPI()
 
 class TodoCreate(BaseModel):
     title: str = Field(min_length=1, max_length=200)
+
+
+class PatchTodo(BaseModel):
+    model_config = {"extra": "forbid"}
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    done: bool | None = None
 
 
 class Todo(BaseModel):
@@ -20,6 +26,12 @@ class Todo(BaseModel):
 class TodoList(BaseModel):
     items: list[Todo]
     total: int
+
+
+class TodoStats(BaseModel):
+    total: int
+    done: int
+    pending: int
 
 
 _todos: list[Todo] = []
@@ -50,10 +62,21 @@ def create_todo(body: TodoCreate) -> Todo:
 def list_todos(
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
+    done: bool | None = Query(default=None),
 ) -> TodoList:
-    sorted_todos = sorted(_todos, key=lambda t: t.id, reverse=True)
+    if done is not None:
+        filtered = [t for t in _todos if t.done is done]
+    else:
+        filtered = list(_todos)
+    sorted_todos = sorted(filtered, key=lambda t: t.id, reverse=True)
     page = sorted_todos[offset : offset + limit]
-    return TodoList(items=page, total=len(_todos))
+    return TodoList(items=page, total=len(filtered))
+
+
+@app.get("/todos/stats")
+def get_stats() -> TodoStats:
+    done_count = sum(1 for t in _todos if t.done)
+    return TodoStats(total=len(_todos), done=done_count, pending=len(_todos) - done_count)
 
 
 @app.get("/todos/{todo_id}")
@@ -61,4 +84,23 @@ def get_todo(todo_id: int) -> Todo:
     for todo in _todos:
         if todo.id == todo_id:
             return todo
+    raise HTTPException(status_code=404, detail="Not Found")
+
+
+@app.patch("/todos/{todo_id}")
+def patch_todo(todo_id: int, body: PatchTodo) -> Todo:
+    for i, todo in enumerate(_todos):
+        if todo.id == todo_id:
+            updates = body.model_dump(exclude_none=True)
+            _todos[i] = todo.model_copy(update=updates)
+            return _todos[i]
+    raise HTTPException(status_code=404, detail="Not Found")
+
+
+@app.delete("/todos/{todo_id}", status_code=204)
+def delete_todo(todo_id: int) -> Response:
+    for i, todo in enumerate(_todos):
+        if todo.id == todo_id:
+            _todos.pop(i)
+            return Response(status_code=204)
     raise HTTPException(status_code=404, detail="Not Found")

--- a/tests/test_todos_delete.py
+++ b/tests/test_todos_delete.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api import app as app_module
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "_todos", [])
+
+
+def _create_todo(title: str) -> dict:
+    return client.post("/todos", json={"title": title}).json()
+
+
+def test_delete_removes_item() -> None:
+    todo = _create_todo("doomed")
+    response = client.delete(f"/todos/{todo['id']}")
+    assert response.status_code == 204
+    get_response = client.get(f"/todos/{todo['id']}")
+    assert get_response.status_code == 404
+
+
+def test_delete_returns_204_empty_body() -> None:
+    todo = _create_todo("doomed")
+    response = client.delete(f"/todos/{todo['id']}")
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_delete_missing_returns_404() -> None:
+    response = client.delete("/todos/999")
+    assert response.status_code == 404
+
+
+def test_delete_reduces_total() -> None:
+    _create_todo("a")
+    _create_todo("b")
+    _create_todo("c")
+    client.delete("/todos/1")
+    response = client.get("/todos")
+    assert response.json()["total"] == 2

--- a/tests/test_todos_filter.py
+++ b/tests/test_todos_filter.py
@@ -1,0 +1,82 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api import app as app_module
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "_todos", [])
+
+
+def _create_todo(title: str) -> dict:
+    return client.post("/todos", json={"title": title}).json()
+
+
+def _mark_done(todo_id: int) -> None:
+    client.patch(f"/todos/{todo_id}", json={"done": True})
+
+
+def test_filter_done_true() -> None:
+    t1 = _create_todo("a")
+    t2 = _create_todo("b")
+    _create_todo("c")
+    _mark_done(t1["id"])
+    _mark_done(t2["id"])
+    response = client.get("/todos", params={"done": "true"})
+    data = response.json()
+    assert len(data["items"]) == 2
+    assert data["total"] == 2
+
+
+def test_filter_done_false() -> None:
+    t1 = _create_todo("a")
+    t2 = _create_todo("b")
+    _create_todo("c")
+    _mark_done(t1["id"])
+    _mark_done(t2["id"])
+    response = client.get("/todos", params={"done": "false"})
+    data = response.json()
+    assert len(data["items"]) == 1
+    assert data["total"] == 1
+
+
+def test_filter_omitted_returns_all() -> None:
+    t1 = _create_todo("a")
+    t2 = _create_todo("b")
+    _create_todo("c")
+    _mark_done(t1["id"])
+    _mark_done(t2["id"])
+    response = client.get("/todos")
+    data = response.json()
+    assert len(data["items"]) == 3
+    assert data["total"] == 3
+
+
+def test_filter_preserves_order() -> None:
+    t1 = _create_todo("a")
+    t2 = _create_todo("b")
+    _create_todo("c")
+    _mark_done(t1["id"])
+    _mark_done(t2["id"])
+    response = client.get("/todos", params={"done": "true"})
+    ids = [item["id"] for item in response.json()["items"]]
+    assert ids == sorted(ids, reverse=True)
+
+
+def test_filter_interacts_with_pagination() -> None:
+    todos = [_create_todo(f"item {i}") for i in range(5)]
+    for t in todos[:3]:
+        _mark_done(t["id"])
+    response = client.get("/todos", params={"done": "true", "limit": 2})
+    data = response.json()
+    assert len(data["items"]) == 2
+    assert data["total"] == 3
+
+
+def test_filter_invalid_value_returns_422() -> None:
+    response = client.get("/todos", params={"done": "maybe"})
+    assert response.status_code == 422

--- a/tests/test_todos_patch.py
+++ b/tests/test_todos_patch.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api import app as app_module
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "_todos", [])
+
+
+def _create_todo(title: str) -> dict:
+    return client.post("/todos", json={"title": title}).json()
+
+
+def test_patch_updates_title() -> None:
+    todo = _create_todo("original")
+    response = client.patch(f"/todos/{todo['id']}", json={"title": "new"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "new"
+    assert data["done"] is False
+
+
+def test_patch_marks_done() -> None:
+    todo = _create_todo("task")
+    response = client.patch(f"/todos/{todo['id']}", json={"done": True})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["done"] is True
+    assert data["title"] == "task"
+
+
+def test_patch_both_fields_at_once() -> None:
+    todo = _create_todo("old")
+    response = client.patch(f"/todos/{todo['id']}", json={"title": "x", "done": True})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "x"
+    assert data["done"] is True
+
+
+def test_patch_empty_body_is_noop() -> None:
+    todo = _create_todo("unchanged")
+    response = client.patch(f"/todos/{todo['id']}", json={})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "unchanged"
+    assert data["done"] is False
+
+
+def test_patch_missing_id_returns_404() -> None:
+    response = client.patch("/todos/999", json={"title": "nope"})
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}
+
+
+def test_patch_rejects_empty_title() -> None:
+    todo = _create_todo("valid")
+    response = client.patch(f"/todos/{todo['id']}", json={"title": ""})
+    assert response.status_code == 422
+
+
+def test_patch_rejects_extra_fields() -> None:
+    todo = _create_todo("valid")
+    response = client.patch(
+        f"/todos/{todo['id']}", json={"created_at": "2020-01-01T00:00:00Z"}
+    )
+    assert response.status_code == 422
+
+
+def test_patch_preserves_created_at() -> None:
+    todo = _create_todo("keep time")
+    original_created_at = todo["created_at"]
+    response = client.patch(f"/todos/{todo['id']}", json={"title": "new title"})
+    assert response.status_code == 200
+    assert response.json()["created_at"] == original_created_at

--- a/tests/test_todos_stats.py
+++ b/tests/test_todos_stats.py
@@ -1,0 +1,56 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api import app as app_module
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "_todos", [])
+
+
+def _create_todo(title: str) -> dict:
+    return client.post("/todos", json={"title": title}).json()
+
+
+def _mark_done(todo_id: int) -> None:
+    client.patch(f"/todos/{todo_id}", json={"done": True})
+
+
+def test_stats_empty_store() -> None:
+    response = client.get("/todos/stats")
+    assert response.status_code == 200
+    assert response.json() == {"total": 0, "done": 0, "pending": 0}
+
+
+def test_stats_after_posts() -> None:
+    for i in range(5):
+        _create_todo(f"item {i}")
+    data = client.get("/todos/stats").json()
+    assert data == {"total": 5, "done": 0, "pending": 5}
+
+
+def test_stats_after_mixed() -> None:
+    todos = [_create_todo(f"item {i}") for i in range(5)]
+    _mark_done(todos[0]["id"])
+    _mark_done(todos[1]["id"])
+    data = client.get("/todos/stats").json()
+    assert data == {"total": 5, "done": 2, "pending": 3}
+
+
+@pytest.mark.parametrize(
+    "total,done_count",
+    [(0, 0), (1, 0), (1, 1), (5, 2), (10, 10)],
+)
+def test_stats_invariant(total: int, done_count: int) -> None:
+    todos = [_create_todo(f"item {i}") for i in range(total)]
+    for t in todos[:done_count]:
+        _mark_done(t["id"])
+    data = client.get("/todos/stats").json()
+    assert data["total"] == data["done"] + data["pending"]
+    assert data["total"] == total
+    assert data["done"] == done_count
+    assert data["pending"] == total - done_count


### PR DESCRIPTION
## Summary

- **PATCH /todos/{id}** — partial update with `PatchTodo` model (`extra="forbid"`, both fields optional). Returns 200 with updated todo, 404 if missing, 422 for validation errors.
- **DELETE /todos/{id}** — returns 204 with empty body on success, 404 if missing.
- **GET /todos?done=true|false** — optional filter on the existing list endpoint. `total` reflects the filtered count for correct pagination.
- **GET /todos/stats** — returns `{"total", "done", "pending"}` aggregate counts. Route registered before `/{id}` to avoid the FastAPI path-parameter routing gotcha.

All 44 tests pass (18 existing + 8 patch + 4 delete + 6 filter + 6 stats including parametrized invariant).

Closes #10

## Test plan

- [x] `pytest -q` exits 0 with 44 passing tests
- [x] All 18 existing tests (health + create + read) pass unchanged
- [x] PATCH: title update, done update, both, empty body noop, 404, empty title 422, extra fields 422, created_at immutability
- [x] DELETE: removes item + subsequent 404, 204 empty body, missing 404, total reduction
- [x] Filter: done=true, done=false, omitted returns all, order preserved, pagination interaction, invalid value 422
- [x] Stats: empty store, all pending, mixed, parametrized invariant (total == done + pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)