### PR TITLE
feat: migrate storage from in-memory list to SQLite

### DIFF
--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -1,9 +1,21 @@
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 from fastapi import FastAPI, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
-app = FastAPI()
+from todo_api.db import _row_to_todo, get_connection, init_schema
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    conn = get_connection()
+    init_schema(conn)
+    conn.close()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 class TodoCreate(BaseModel):
@@ -34,13 +46,6 @@ class TodoStats(BaseModel):
     pending: int
 
 
-_todos: list[Todo] = []
-
-
-def _next_id() -> int:
-    return len(_todos) + 1
-
-
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
@@ -48,14 +53,18 @@ def health() -> dict[str, str]:
 
 @app.post("/todos", status_code=201)
 def create_todo(body: TodoCreate) -> Todo:
-    todo = Todo(
-        id=_next_id(),
-        title=body.title,
-        done=False,
-        created_at=datetime.now(timezone.utc),
+    now = datetime.now(timezone.utc)
+    conn = get_connection()
+    cursor = conn.execute(
+        "INSERT INTO todos (title, done, created_at) VALUES (?, 0, ?)",
+        (body.title, now.isoformat()),
     )
-    _todos.append(todo)
-    return todo
+    conn.commit()
+    row = conn.execute(
+        "SELECT * FROM todos WHERE id = ?", (cursor.lastrowid,)
+    ).fetchone()
+    conn.close()
+    return _row_to_todo(row)
 
 
 @app.get("/todos")
@@ -64,43 +73,71 @@ def list_todos(
     offset: int = Query(default=0, ge=0),
     done: bool | None = Query(default=None),
 ) -> TodoList:
-    if done is not None:
-        filtered = [t for t in _todos if t.done is done]
-    else:
-        filtered = list(_todos)
-    sorted_todos = sorted(filtered, key=lambda t: t.id, reverse=True)
-    page = sorted_todos[offset : offset + limit]
-    return TodoList(items=page, total=len(filtered))
+    conn = get_connection()
+    done_val = int(done) if done is not None else None
+    rows = conn.execute(
+        "SELECT * FROM todos WHERE (? IS NULL OR done = ?) "
+        "ORDER BY id DESC LIMIT ? OFFSET ?",
+        (done_val, done_val, limit, offset),
+    ).fetchall()
+    total = conn.execute(
+        "SELECT COUNT(*) FROM todos WHERE (? IS NULL OR done = ?)",
+        (done_val, done_val),
+    ).fetchone()[0]
+    conn.close()
+    return TodoList(items=[_row_to_todo(r) for r in rows], total=total)
 
 
 @app.get("/todos/stats")
 def get_stats() -> TodoStats:
-    done_count = sum(1 for t in _todos if t.done)
-    return TodoStats(total=len(_todos), done=done_count, pending=len(_todos) - done_count)
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT COUNT(*) AS total, SUM(done) AS done FROM todos"
+    ).fetchone()
+    conn.close()
+    total = row["total"]
+    done_count = row["done"] or 0
+    return TodoStats(total=total, done=done_count, pending=total - done_count)
 
 
 @app.get("/todos/{todo_id}")
 def get_todo(todo_id: int) -> Todo:
-    for todo in _todos:
-        if todo.id == todo_id:
-            return todo
-    raise HTTPException(status_code=404, detail="Not Found")
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT * FROM todos WHERE id = ?", (todo_id,)
+    ).fetchone()
+    conn.close()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    return _row_to_todo(row)
 
 
 @app.patch("/todos/{todo_id}")
 def patch_todo(todo_id: int, body: PatchTodo) -> Todo:
-    for i, todo in enumerate(_todos):
-        if todo.id == todo_id:
-            updates = body.model_dump(exclude_none=True)
-            _todos[i] = todo.model_copy(update=updates)
-            return _todos[i]
-    raise HTTPException(status_code=404, detail="Not Found")
+    conn = get_connection()
+    done_val = int(body.done) if body.done is not None else None
+    cursor = conn.execute(
+        "UPDATE todos SET title = COALESCE(?, title), done = COALESCE(?, done) "
+        "WHERE id = ?",
+        (body.title, done_val, todo_id),
+    )
+    conn.commit()
+    if cursor.rowcount == 0:
+        conn.close()
+        raise HTTPException(status_code=404, detail="Not Found")
+    row = conn.execute(
+        "SELECT * FROM todos WHERE id = ?", (todo_id,)
+    ).fetchone()
+    conn.close()
+    return _row_to_todo(row)
 
 
 @app.delete("/todos/{todo_id}", status_code=204)
 def delete_todo(todo_id: int) -> Response:
-    for i, todo in enumerate(_todos):
-        if todo.id == todo_id:
-            _todos.pop(i)
-            return Response(status_code=204)
-    raise HTTPException(status_code=404, detail="Not Found")
+    conn = get_connection()
+    cursor = conn.execute("DELETE FROM todos WHERE id = ?", (todo_id,))
+    conn.commit()
+    conn.close()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Not Found")
+    return Response(status_code=204)

--- a/src/todo_api/db.py
+++ b/src/todo_api/db.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from todo_api.app import Todo
+
+DB_PATH: Path = Path(os.environ.get("TODO_DB_PATH", ":memory:"))
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, detect_types=sqlite3.PARSE_DECLTYPES)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS todos ("
+        "    id         INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "    title      TEXT    NOT NULL,"
+        "    done       INTEGER NOT NULL DEFAULT 0,"
+        "    created_at TEXT    NOT NULL"
+        ")"
+    )
+    conn.commit()
+
+
+def _row_to_todo(row: sqlite3.Row) -> Todo:
+    from todo_api.app import Todo
+
+    return Todo(
+        id=row["id"],
+        title=row["title"],
+        done=bool(row["done"]),
+        created_at=datetime.fromisoformat(row["created_at"]),
+    )

--- a/tests/test_todos_create.py
+++ b/tests/test_todos_create.py
@@ -3,15 +3,16 @@ from datetime import datetime
 import pytest
 from fastapi.testclient import TestClient
 
-from todo_api import app as app_module
+from todo_api import db as db_module
 from todo_api.app import app
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "_todos", [])
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
+    db_module.init_schema(db_module.get_connection())
 
 
 def test_create_todo_returns_201_with_payload() -> None:

--- a/tests/test_todos_delete.py
+++ b/tests/test_todos_delete.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from todo_api import app as app_module
+from todo_api import db as db_module
 from todo_api.app import app
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "_todos", [])
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
+    db_module.init_schema(db_module.get_connection())
 
 
 def _create_todo(title: str) -> dict:

--- a/tests/test_todos_filter.py
+++ b/tests/test_todos_filter.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from todo_api import app as app_module
+from todo_api import db as db_module
 from todo_api.app import app
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "_todos", [])
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
+    db_module.init_schema(db_module.get_connection())
 
 
 def _create_todo(title: str) -> dict:

--- a/tests/test_todos_patch.py
+++ b/tests/test_todos_patch.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from todo_api import app as app_module
+from todo_api import db as db_module
 from todo_api.app import app
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "_todos", [])
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
+    db_module.init_schema(db_module.get_connection())
 
 
 def _create_todo(title: str) -> dict:

--- a/tests/test_todos_read.py
+++ b/tests/test_todos_read.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from todo_api import app as app_module
+from todo_api import db as db_module
 from todo_api.app import app
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "_todos", [])
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
+    db_module.init_schema(db_module.get_connection())
 
 
 def _create_todo(title: str) -> dict:

--- a/tests/test_todos_stats.py
+++ b/tests/test_todos_stats.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from todo_api import app as app_module
+from todo_api import db as db_module
 from todo_api.app import app
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _reset_todos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "_todos", [])
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
+    db_module.init_schema(db_module.get_connection())
 
 
 def _create_todo(title: str) -> dict:


### PR DESCRIPTION
## Summary

- Add `src/todo_api/db.py` — new module encapsulating SQLite connection (`get_connection`), schema initialization (`init_schema`), and row-to-model conversion (`_row_to_todo`)
- Rewrite all six route handlers in `app.py` to use parameterized SQL via `db.py`, removing the in-memory `_todos` list and `_next_id` helper entirely
- Replace `_reset_todos` fixture with `isolated_db` (monkeypatches `DB_PATH` to a tmp file) in all six affected test files

Closes #13

## Test plan

- [x] All 44 existing tests pass unchanged (only fixtures modified)
- [x] `grep -rE "^_todos\b|\b_next_id\b" src/todo_api/` returns no matches
- [x] SQLite schema creation verified: `todos` table present
- [x] No format-string SQL — all queries use `?` parameterized placeholders
- [x] No new runtime dependencies added (`sqlite3` is stdlib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)