### PR TITLE
spec: #16 — Add tags: many-to-many tagging for todos with filter + tag CRUD [high-risk]

### DIFF
--- a/docs/change-sets/16.md
+++ b/docs/change-sets/16.md
@@ -1,0 +1,202 @@
+---
+risk: high
+issue: 16
+base: main
+---
+
+# Change-set for #16 — Add tags: many-to-many tagging for todos with filter + tag CRUD
+
+## Scope
+
+Introduce a `tags` entity and `todo_tags` join table. Ship CRUD for tags, tag-assignment endpoints on todos, extend `GET /todos` with an OR-semantics `tag_ids` filter, and add a `tags: list[Tag]` field to every Todo response. Out of scope: tag rename, tag metadata, per-tag stats, AND filter semantics.
+
+## Files to touch
+
+- Modify: `src/todo_api/db.py` — extend `init_schema` with two new tables + index; add `get_tags_for_todo` and `_row_to_tag` helpers; update `_row_to_todo` signature to accept `conn` so it can populate `tags`.
+- Modify: `src/todo_api/app.py` — add `Tag` and `TagCreate` Pydantic models; update `Todo` model with `tags: list[Tag] = []`; update all `_row_to_todo` call sites to pass `conn`; add five new endpoints; extend `list_todos` with `tag_ids` query param and updated SQL.
+- Create: `tests/test_tags_crud.py` — ~7 tests for tag POST/GET/DELETE, 409 on duplicate, cascade cleanup.
+- Create: `tests/test_todos_tags.py` — ~8 tests for tag attachment/detachment, idempotency, unknown tag 400, cascade when todo deleted, tags field in todo response.
+- Create: `tests/test_todos_tag_filter.py` — ~5 tests for `tag_ids` OR-filter, combined with `done`, empty param, unknown tag_id returns 200 empty.
+
+## Public API / contract changes
+
+**Todo response shape — before:**
+```json
+{"id": 1, "title": "x", "done": false, "created_at": "2026-01-01T00:00:00Z"}
+```
+**Todo response shape — after (breaking addition):**
+```json
+{"id": 1, "title": "x", "done": false, "created_at": "2026-01-01T00:00:00Z", "tags": []}
+```
+
+**New endpoints:**
+- `POST /tags` → 201 `Tag` | 409 `{"detail":"Tag already exists"}`
+- `GET /tags` → 200 `{"items": [Tag, ...], "total": N}` ordered by `id` DESC
+- `DELETE /tags/{id}` → 204 | 404
+- `POST /todos/{id}/tags` body `{"tag_ids":[1,2]}` → 200 `Todo` with `tags` populated | 404 (todo missing) | 400 `{"detail":"Unknown tag_id: N"}`
+- `DELETE /todos/{id}/tags/{tag_id}` → 204 | 404
+
+**Extended endpoint:**
+- `GET /todos` gains `tag_ids: list[int] | None = Query(default=None)` — OR semantics, AND'd with existing `done` filter.
+
+**`_row_to_todo` signature change (internal but cross-module):**
+Before: `_row_to_todo(row: sqlite3.Row) -> Todo`
+After: `_row_to_todo(row: sqlite3.Row, conn: sqlite3.Connection) -> Todo`
+
+## Implementation notes
+
+### `src/todo_api/db.py`
+
+Append to `init_schema` after `todos` table creation:
+```sql
+CREATE TABLE IF NOT EXISTS tags (
+    id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT    NOT NULL UNIQUE COLLATE NOCASE
+);
+CREATE TABLE IF NOT EXISTS todo_tags (
+    todo_id INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+    tag_id  INTEGER NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,
+    PRIMARY KEY (todo_id, tag_id)
+);
+CREATE INDEX IF NOT EXISTS idx_todo_tags_tag ON todo_tags(tag_id);
+```
+
+Add helpers:
+```python
+def _row_to_tag(row: sqlite3.Row) -> Tag:
+    from todo_api.app import Tag
+    return Tag(id=row["id"], name=row["name"])
+
+def get_tags_for_todo(conn: sqlite3.Connection, todo_id: int) -> list[Tag]:
+    rows = conn.execute(
+        "SELECT t.id, t.name FROM tags t "
+        "JOIN todo_tags tt ON tt.tag_id = t.id "
+        "WHERE tt.todo_id = ? ORDER BY t.id",
+        (todo_id,)
+    ).fetchall()
+    return [_row_to_tag(r) for r in rows]
+```
+
+Update `_row_to_todo` to accept `conn` and call `get_tags_for_todo`.
+
+### `src/todo_api/app.py`
+
+Add to Pydantic models:
+```python
+class Tag(BaseModel):
+    id: int
+    name: str
+
+class TagCreate(BaseModel):
+    model_config = {"extra": "forbid"}
+    name: str = Field(min_length=1, max_length=50)
+
+class TagAssign(BaseModel):
+    model_config = {"extra": "forbid"}
+    tag_ids: list[int]
+```
+
+Update `Todo`:
+```python
+class Todo(BaseModel):
+    id: int
+    title: str
+    done: bool
+    created_at: datetime
+    tags: list[Tag] = []
+```
+
+Add `TagList` (same shape as `TodoList`):
+```python
+class TagList(BaseModel):
+    items: list[Tag]
+    total: int
+```
+
+Update all four `_row_to_todo(row)` calls to `_row_to_todo(row, conn)` in `create_todo`, `list_todos` (inside list comprehension), `get_todo`, and `patch_todo`.
+
+**`list_todos` SQL with `tag_ids` filter:**
+```python
+tag_ids: list[int] | None = Query(default=None)
+
+has_tag_filter = int(bool(tag_ids))  # 1 if filter active, 0 if not
+placeholders = ",".join("?" * len(tag_ids)) if tag_ids else ""
+tag_params = list(tag_ids) if tag_ids else []
+
+rows = conn.execute(
+    f"SELECT DISTINCT t.* FROM todos t "
+    f"LEFT JOIN todo_tags tt ON tt.todo_id = t.id "
+    f"WHERE (? IS NULL OR t.done = ?) "
+    f"  AND (? = 0 OR tt.tag_id IN ({placeholders or 'NULL'})) "
+    f"ORDER BY t.id DESC LIMIT ? OFFSET ?",
+    [done_val, done_val, has_tag_filter] + tag_params + [limit, offset],
+).fetchall()
+```
+Mirror the same WHERE clause in the `COUNT(DISTINCT t.id)` query for `total`.
+
+**Tag endpoints:**
+```python
+@app.post("/tags", status_code=201)
+def create_tag(body: TagCreate) -> Tag: ...
+# INSERT INTO tags (name) VALUES (?)
+# Catch sqlite3.IntegrityError → 409 {"detail":"Tag already exists"}
+
+@app.get("/tags")
+def list_tags() -> TagList: ...
+# SELECT * FROM tags ORDER BY id DESC
+
+@app.delete("/tags/{tag_id}", status_code=204)
+def delete_tag(tag_id: int) -> Response: ...
+# DELETE FROM tags WHERE id = ?; rowcount==0 → 404
+
+@app.post("/todos/{todo_id}/tags")
+def assign_tags(todo_id: int, body: TagAssign) -> Todo: ...
+# Check todo exists → 404
+# For each tag_id: SELECT id FROM tags WHERE id=?; first missing → 400
+# INSERT OR IGNORE INTO todo_tags (todo_id, tag_id) VALUES (?,?)
+# Return _row_to_todo(todo_row, conn)
+
+@app.delete("/todos/{todo_id}/tags/{tag_id}", status_code=204)
+def remove_tag(todo_id: int, tag_id: int) -> Response: ...
+# DELETE FROM todo_tags WHERE todo_id=? AND tag_id=?; rowcount==0 → 404
+```
+
+### Test plan
+
+**`tests/test_tags_crud.py`** (~7 tests):
+1. `POST /tags` returns 201 with `id` and `name`
+2. `POST /tags` with same name (different case) returns 409
+3. `GET /tags` returns items + total, ordered by id DESC
+4. `GET /tags` empty returns `{"items":[],"total":0}`
+5. `DELETE /tags/{id}` returns 204
+6. `DELETE /tags/{id}` missing returns 404
+7. Deleting a tag cascades: `todo_tags` row gone, todo's `tags` field returns `[]`
+
+**`tests/test_todos_tags.py`** (~8 tests):
+1. `POST /todos/{id}/tags` attaches tags; response includes `tags` list
+2. Re-posting same tag_ids is idempotent (no error, same result)
+3. `DELETE /todos/{id}/tags/{tag_id}` returns 204 and tag is gone from todo
+4. `DELETE /todos/{id}/tags/{tag_id}` on non-existent link returns 404
+5. `POST /todos/{id}/tags` with unknown tag_id returns 400
+6. `POST /todos/{id}/tags` with unknown todo_id returns 404
+7. Deleting a todo cascades: `todo_tags` rows gone (verify via GET /todos/{id} 404 and no orphan)
+8. Newly created todo always has `tags: []`
+
+**`tests/test_todos_tag_filter.py`** (~5 tests):
+1. `GET /todos?tag_ids=N` returns only todos with that tag
+2. `GET /todos?tag_ids=1&tag_ids=2` is OR (union of both tagged todos)
+3. `GET /todos?tag_ids=N&done=true` combines both filters (AND)
+4. `GET /todos` without `tag_ids` returns all todos unchanged
+5. `GET /todos?tag_ids=9999` (unknown tag) returns 200 with empty items (no 400)
+
+**Existing tests (40):** must all pass unchanged. No existing test uses strict dict equality on todo objects, so the new `tags: []` field does not require updating any existing assertion.
+
+## Risk justification
+
+This change modifies the database schema (two new tables), alters the public HTTP API surface (five new endpoints + breaking Todo response shape addition), and changes `GET /todos` query semantics — all three criteria from the high-risk rubric apply simultaneously.
+
+## Open questions
+
+1. The `assign_tags` endpoint body model is not named in the issue. `TagAssign` is used here; the Implementer may choose any name.
+2. The issue says "first unknown tag" for the 400 error. The order is undefined if `tag_ids` is `[5,3]` — implementing in list order is simplest and matches the spec.
+3. The `total` for `GET /todos` with `tag_ids` should use `COUNT(DISTINCT t.id)` to avoid double-counting todos with multiple matching tags; confirm this is the intended behavior.


### PR DESCRIPTION
## High-risk change-set for #16

This PR contains the Planner's change-set for a **high-risk** issue. The Implementer has **not** been dispatched.

**To proceed:** review `docs/change-sets/16.md`, make any corrections, then manually dispatch the Implementer:

```\ngh workflow run autoagent-implementer.yml -f issue_number=16 -f base_branch=main\n```