### PR TITLE
feat: add per-user and per-IP rate limiting

### DIFF
--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -13,6 +13,7 @@ from todo_api.auth import (
     verify_password,
 )
 from todo_api.db import _row_to_tag, _row_to_todo, get_connection, get_tags_for_todo, init_schema
+from todo_api.rate_limit import anon_rate_limit, authed_rate_limit
 
 
 @asynccontextmanager
@@ -104,7 +105,7 @@ class TodoStats(BaseModel):
 # --- Auth endpoints ---
 
 @app.post("/auth/register", status_code=201)
-def register(body: UserCreate) -> UserResponse:
+def register(body: UserCreate, _: str = Depends(anon_rate_limit)) -> UserResponse:
     conn = get_connection()
     now = datetime.now(timezone.utc)
     hashed = hash_password(body.password)
@@ -123,7 +124,7 @@ def register(body: UserCreate) -> UserResponse:
 
 
 @app.post("/auth/login")
-def login(body: LoginRequest) -> LoginResponse:
+def login(body: LoginRequest, _: str = Depends(anon_rate_limit)) -> LoginResponse:
     conn = get_connection()
     row = conn.execute(
         "SELECT * FROM users WHERE email = ?", (body.email,)
@@ -138,7 +139,7 @@ def login(body: LoginRequest) -> LoginResponse:
 
 
 @app.get("/auth/me")
-def get_me(user_id: int = Depends(get_current_user)) -> UserResponse:
+def get_me(user_id: int = Depends(authed_rate_limit)) -> UserResponse:
     conn = get_connection()
     row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
     conn.close()
@@ -159,7 +160,7 @@ def health() -> dict[str, str]:
 # --- Todo endpoints ---
 
 @app.post("/todos", status_code=201)
-def create_todo(body: TodoCreate, user_id: int = Depends(get_current_user)) -> Todo:
+def create_todo(body: TodoCreate, user_id: int = Depends(authed_rate_limit)) -> Todo:
     now = datetime.now(timezone.utc)
     conn = get_connection()
     cursor = conn.execute(
@@ -177,7 +178,7 @@ def create_todo(body: TodoCreate, user_id: int = Depends(get_current_user)) -> T
 
 @app.get("/todos")
 def list_todos(
-    user_id: int = Depends(get_current_user),
+    user_id: int = Depends(authed_rate_limit),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
     done: bool | None = Query(default=None),
@@ -212,7 +213,7 @@ def list_todos(
 
 
 @app.get("/todos/stats")
-def get_stats(user_id: int = Depends(get_current_user)) -> TodoStats:
+def get_stats(user_id: int = Depends(authed_rate_limit)) -> TodoStats:
     conn = get_connection()
     row = conn.execute(
         "SELECT COUNT(*) AS total, SUM(done) AS done FROM todos WHERE user_id = ?",
@@ -225,7 +226,7 @@ def get_stats(user_id: int = Depends(get_current_user)) -> TodoStats:
 
 
 @app.get("/todos/{todo_id}")
-def get_todo(todo_id: int, user_id: int = Depends(get_current_user)) -> Todo:
+def get_todo(todo_id: int, user_id: int = Depends(authed_rate_limit)) -> Todo:
     conn = get_connection()
     row = conn.execute(
         "SELECT * FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
@@ -240,7 +241,7 @@ def get_todo(todo_id: int, user_id: int = Depends(get_current_user)) -> Todo:
 
 @app.patch("/todos/{todo_id}")
 def patch_todo(
-    todo_id: int, body: PatchTodo, user_id: int = Depends(get_current_user)
+    todo_id: int, body: PatchTodo, user_id: int = Depends(authed_rate_limit)
 ) -> Todo:
     conn = get_connection()
     done_val = int(body.done) if body.done is not None else None
@@ -262,7 +263,7 @@ def patch_todo(
 
 
 @app.delete("/todos/{todo_id}", status_code=204)
-def delete_todo(todo_id: int, user_id: int = Depends(get_current_user)) -> Response:
+def delete_todo(todo_id: int, user_id: int = Depends(authed_rate_limit)) -> Response:
     conn = get_connection()
     cursor = conn.execute(
         "DELETE FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
@@ -277,7 +278,7 @@ def delete_todo(todo_id: int, user_id: int = Depends(get_current_user)) -> Respo
 # --- Tag endpoints ---
 
 @app.post("/tags", status_code=201)
-def create_tag(body: TagCreate, user_id: int = Depends(get_current_user)) -> Tag:
+def create_tag(body: TagCreate, user_id: int = Depends(authed_rate_limit)) -> Tag:
     conn = get_connection()
     try:
         cursor = conn.execute(
@@ -295,7 +296,7 @@ def create_tag(body: TagCreate, user_id: int = Depends(get_current_user)) -> Tag
 
 
 @app.get("/tags")
-def list_tags(user_id: int = Depends(get_current_user)) -> TagList:
+def list_tags(user_id: int = Depends(authed_rate_limit)) -> TagList:
     conn = get_connection()
     rows = conn.execute(
         "SELECT * FROM tags WHERE user_id = ? ORDER BY id DESC", (user_id,)
@@ -305,7 +306,7 @@ def list_tags(user_id: int = Depends(get_current_user)) -> TagList:
 
 
 @app.delete("/tags/{tag_id}", status_code=204)
-def delete_tag(tag_id: int, user_id: int = Depends(get_current_user)) -> Response:
+def delete_tag(tag_id: int, user_id: int = Depends(authed_rate_limit)) -> Response:
     conn = get_connection()
     cursor = conn.execute(
         "DELETE FROM tags WHERE id = ? AND user_id = ?", (tag_id, user_id)
@@ -321,7 +322,7 @@ def delete_tag(tag_id: int, user_id: int = Depends(get_current_user)) -> Respons
 
 @app.post("/todos/{todo_id}/tags")
 def assign_tags(
-    todo_id: int, body: TagAssign, user_id: int = Depends(get_current_user)
+    todo_id: int, body: TagAssign, user_id: int = Depends(authed_rate_limit)
 ) -> Todo:
     conn = get_connection()
     row = conn.execute(
@@ -352,7 +353,7 @@ def assign_tags(
 
 @app.delete("/todos/{todo_id}/tags/{tag_id}", status_code=204)
 def remove_tag(
-    todo_id: int, tag_id: int, user_id: int = Depends(get_current_user)
+    todo_id: int, tag_id: int, user_id: int = Depends(authed_rate_limit)
 ) -> Response:
     conn = get_connection()
     todo_row = conn.execute(

--- a/src/todo_api/rate_limit.py
+++ b/src/todo_api/rate_limit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import math
+import time
+
+from fastapi import Depends, HTTPException, Request
+
+from todo_api.auth import get_current_user
+
+
+class TokenBucket:
+    def __init__(self, capacity: int, refill_rate_per_second: float) -> None:
+        self.capacity = capacity
+        self.refill_rate = refill_rate_per_second
+        self.tokens = float(capacity)
+        self._last_refill: float | None = None
+
+    def consume(self, n: int = 1, now: float | None = None) -> bool:
+        if n <= 0:
+            raise ValueError("n must be a positive integer")
+        if now is None:
+            now = time.monotonic()
+        if self._last_refill is not None:
+            elapsed = now - self._last_refill
+            self.tokens = min(self.capacity, self.tokens + elapsed * self.refill_rate)
+        self._last_refill = now
+        if self.tokens >= n:
+            self.tokens -= n
+            return True
+        return False
+
+
+_buckets: dict[str, TokenBucket] = {}
+
+
+def _get_bucket(key: str, capacity: int, refill_rate: float) -> TokenBucket:
+    if key not in _buckets:
+        _buckets[key] = TokenBucket(capacity, refill_rate)
+    return _buckets[key]
+
+
+def reset_buckets() -> None:
+    _buckets.clear()
+
+
+_AUTHED_CAPACITY = 60
+_AUTHED_REFILL = 1.0
+_ANON_CAPACITY = 10
+_ANON_REFILL = 10.0 / 60.0
+
+
+def _retry_after(refill_rate: float) -> str:
+    return str(max(1, math.ceil(1 / refill_rate)))
+
+
+def authed_rate_limit(user_id: int = Depends(get_current_user)) -> int:
+    bucket = _get_bucket(f"user:{user_id}", _AUTHED_CAPACITY, _AUTHED_REFILL)
+    if not bucket.consume():
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": _retry_after(_AUTHED_REFILL)},
+        )
+    return user_id
+
+
+def anon_rate_limit(request: Request) -> str:
+    host = request.client.host if request.client else "unknown"
+    bucket = _get_bucket(f"ip:{host}", _ANON_CAPACITY, _ANON_REFILL)
+    if not bucket.consume():
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": _retry_after(_ANON_REFILL)},
+        )
+    return host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,15 +4,17 @@ import pytest
 from fastapi.testclient import TestClient
 
 from todo_api import db as db_module
+from todo_api import rate_limit
 from todo_api.app import app
 
 
 @pytest.fixture(autouse=True)
-def isolated_db(tmp_path, monkeypatch):
+def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
     conn = db_module.get_connection()
     db_module.init_schema(conn)
     conn.close()
+    rate_limit.reset_buckets()
 
 
 @pytest.fixture

--- a/tests/test_rate_limit_anon.py
+++ b/tests/test_rate_limit_anon.py
@@ -1,0 +1,109 @@
+import uuid
+
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from todo_api import rate_limit
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+def _unique_email() -> str:
+    return f"anon-{uuid.uuid4()}@example.com"
+
+
+def test_register_limited_to_10_per_minute_per_ip() -> None:
+    for i in range(10):
+        resp = client.post(
+            "/auth/register",
+            json={"email": _unique_email(), "password": "testpass123"},
+        )
+        assert resp.status_code in (201, 409), f"Request {i+1}: {resp.status_code}"
+    resp = client.post(
+        "/auth/register",
+        json={"email": _unique_email(), "password": "testpass123"},
+    )
+    assert resp.status_code == 429
+
+
+def test_login_shares_bucket_with_register() -> None:
+    for i in range(5):
+        client.post(
+            "/auth/register",
+            json={"email": _unique_email(), "password": "testpass123"},
+        )
+    email = _unique_email()
+    client.post("/auth/register", json={"email": email, "password": "testpass123"})
+    rate_limit.reset_buckets()
+    for i in range(5):
+        client.post(
+            "/auth/register",
+            json={"email": _unique_email(), "password": "testpass123"},
+        )
+    for i in range(5):
+        client.post(
+            "/auth/login",
+            json={"email": email, "password": "testpass123"},
+        )
+    resp = client.post(
+        "/auth/login",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert resp.status_code == 429
+
+
+def test_different_ips_have_independent_buckets() -> None:
+    fake_ip = ["10.0.0.1"]
+
+    def override_anon_rate_limit(request: Request) -> str:
+        host = fake_ip[0]
+        bucket = rate_limit._get_bucket(
+            f"ip:{host}", rate_limit._ANON_CAPACITY, rate_limit._ANON_REFILL
+        )
+        if not bucket.consume():
+            from fastapi import HTTPException
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": rate_limit._retry_after(rate_limit._ANON_REFILL)},
+            )
+        return host
+
+    app.dependency_overrides[rate_limit.anon_rate_limit] = override_anon_rate_limit
+    try:
+        for _ in range(10):
+            client.post(
+                "/auth/register",
+                json={"email": _unique_email(), "password": "testpass123"},
+            )
+        resp = client.post(
+            "/auth/register",
+            json={"email": _unique_email(), "password": "testpass123"},
+        )
+        assert resp.status_code == 429
+
+        fake_ip[0] = "10.0.0.2"
+        resp = client.post(
+            "/auth/register",
+            json={"email": _unique_email(), "password": "testpass123"},
+        )
+        assert resp.status_code == 201
+    finally:
+        app.dependency_overrides.pop(rate_limit.anon_rate_limit, None)
+
+
+def test_429_response_includes_retry_after() -> None:
+    for _ in range(10):
+        client.post(
+            "/auth/register",
+            json={"email": _unique_email(), "password": "testpass123"},
+        )
+    resp = client.post(
+        "/auth/register",
+        json={"email": _unique_email(), "password": "testpass123"},
+    )
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers
+    val = int(resp.headers["Retry-After"])
+    assert val >= 1

--- a/tests/test_rate_limit_authed.py
+++ b/tests/test_rate_limit_authed.py
@@ -1,0 +1,66 @@
+import uuid
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from todo_api import rate_limit
+from todo_api.app import app
+
+client = TestClient(app)
+
+
+def _make_user() -> dict:
+    email = f"rl-{uuid.uuid4()}@example.com"
+    client.post("/auth/register", json={"email": email, "password": "testpass123"})
+    resp = client.post("/auth/login", json={"email": email, "password": "testpass123"})
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def test_authed_user_gets_60_requests_per_minute() -> None:
+    headers = _make_user()
+    for i in range(60):
+        resp = client.get("/todos", headers=headers)
+        assert resp.status_code == 200, f"Request {i+1} failed with {resp.status_code}"
+
+
+def test_authed_user_hits_429_on_61st() -> None:
+    headers = _make_user()
+    for _ in range(60):
+        client.get("/todos", headers=headers)
+    resp = client.get("/todos", headers=headers)
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers
+    assert resp.headers["Retry-After"].isdigit()
+
+
+def test_two_users_have_independent_buckets() -> None:
+    headers_a = _make_user()
+    headers_b = _make_user()
+    for _ in range(60):
+        client.get("/todos", headers=headers_a)
+    assert client.get("/todos", headers=headers_a).status_code == 429
+    assert client.get("/todos", headers=headers_b).status_code == 200
+
+
+def test_bucket_resets_on_refill() -> None:
+    headers = _make_user()
+    for _ in range(60):
+        client.get("/todos", headers=headers)
+    assert client.get("/todos", headers=headers).status_code == 429
+
+    mono = [0.0]
+    original_consume = rate_limit.TokenBucket.consume
+
+    def patched_consume(self, n=1, now=None):
+        return original_consume(self, n, now=mono[0])
+
+    mono[0] = 1e9
+    with patch.object(rate_limit.TokenBucket, "consume", patched_consume):
+        resp = client.get("/todos", headers=headers)
+    assert resp.status_code == 200
+
+
+def test_health_is_not_rate_limited() -> None:
+    for _ in range(100):
+        resp = client.get("/health")
+        assert resp.status_code == 200

--- a/tests/test_rate_limit_unit.py
+++ b/tests/test_rate_limit_unit.py
@@ -1,0 +1,48 @@
+import pytest
+
+from todo_api.rate_limit import TokenBucket
+
+
+def test_fresh_bucket_allows_capacity_requests() -> None:
+    bucket = TokenBucket(capacity=5, refill_rate_per_second=1.0)
+    for _ in range(5):
+        assert bucket.consume(now=0.0) is True
+
+
+def test_bucket_denies_when_exhausted() -> None:
+    bucket = TokenBucket(capacity=5, refill_rate_per_second=1.0)
+    for _ in range(5):
+        bucket.consume(now=0.0)
+    assert bucket.consume(now=0.0) is False
+
+
+def test_bucket_refills_over_time() -> None:
+    bucket = TokenBucket(capacity=5, refill_rate_per_second=1.0)
+    for _ in range(5):
+        bucket.consume(now=0.0)
+    assert bucket.consume(now=0.0) is False
+    assert bucket.consume(now=1.0) is True
+
+
+def test_bucket_refill_caps_at_capacity() -> None:
+    bucket = TokenBucket(capacity=5, refill_rate_per_second=1.0)
+    bucket.consume(1, now=0.0)
+    results = []
+    for i in range(6):
+        results.append(bucket.consume(now=10.0 + i * 0.001))
+    assert results.count(True) == 5
+    assert results[5] is False
+
+
+def test_consume_n() -> None:
+    bucket = TokenBucket(capacity=5, refill_rate_per_second=1.0)
+    assert bucket.consume(3, now=0.0) is True
+    assert bucket.consume(3, now=0.0) is False
+
+
+def test_consume_negative_raises() -> None:
+    bucket = TokenBucket(capacity=5, refill_rate_per_second=1.0)
+    with pytest.raises(ValueError):
+        bucket.consume(-1)
+    with pytest.raises(ValueError):
+        bucket.consume(0)


### PR DESCRIPTION
## Summary

- Adds pure-Python in-memory token bucket rate limiter (`src/todo_api/rate_limit.py`) with two tiers: 60 req/min per authenticated user, 10 req/min per client IP for `/auth/register` and `/auth/login`
- Replaces `Depends(get_current_user)` with `Depends(authed_rate_limit)` on all authed endpoints; adds `Depends(anon_rate_limit)` to register/login
- `GET /health` is explicitly excluded — no rate limiting on liveness probes
- Returns `429 Too Many Requests` with `Retry-After` header when bucket is exhausted
- 15 new tests across 3 files (unit, authed integration, anon integration), 99 total passing

Closes #22

## Test plan

- [x] `pytest -q` passes (99 tests, 0 failures)
- [x] Unit tests verify TokenBucket mechanics: capacity, exhaustion, refill, cap, batch consume, negative input
- [x] Authed integration tests verify 60-request limit, 429 on 61st, independent user buckets, refill recovery, health exclusion
- [x] Anon integration tests verify 10-request IP limit, shared bucket across register/login, independent IP buckets, Retry-After header

🤖 Generated with [Claude Code](https://claude.com/claude-code)