### PR TITLE
spec: #28 — Add WebSocket /ws/todos that streams todo events to authenticated users [high-risk]

### DIFF
--- a/docs/change-sets/28.md
+++ b/docs/change-sets/28.md
@@ -1,0 +1,63 @@
+---
+risk: high
+issue: 28
+base: main
+---
+
+# Change-set for #28 — Add WebSocket /ws/todos that streams todo events to authenticated users
+
+## Scope
+
+Add a WebSocket endpoint `WS /ws/todos` that authenticates via JWT on upgrade and streams per-user todo lifecycle events (`created`, `updated`, `deleted`) in real time. An in-memory `EventBus` pub/sub module fans events out to all open sockets for a given user. Mutations in `POST /todos`, `PATCH /todos/{id}`, `DELETE /todos/{id}`, `POST /todos/{id}/tags`, and `DELETE /todos/{id}/tags/{tag_id}` publish events after commit. Out of scope: Redis, reconnect/heartbeat, binary frames, event filtering, rate-limiting the WS connection itself.
+
+## Files to touch
+
+- Create: `src/todo_api/events.py` — new `EventBus` class and module-level `bus` singleton
+- Modify: `src/todo_api/auth.py` — add `decode_token_from_ws_headers(ws)` helper that raises `WebSocketException` on bad/missing JWT
+- Modify: `src/todo_api/app.py` — add `@app.websocket("/ws/todos")` handler; wire `bus.publish(...)` into the five mutation endpoints; pre-fetch todo before `DELETE` so the deleted payload is available
+- Create: `tests/test_websocket.py` — ~10 async tests covering auth rejection, hello frame, per-event types, user isolation, tag events, cleanup on disconnect
+
+## Public API / contract changes
+
+New endpoint added:
+
+```
+WS /ws/todos
+  Headers:  Authorization: Bearer <jwt>  (required on upgrade)
+  Reject:   WebSocketException(code=1008) if missing/invalid/expired
+  On open:  {"type": "hello", "user_id": <int>}
+  On event: {"type": "created"|"updated"|"deleted", "todo": {id, title, done, created_at, tags: [...]}}
+```
+
+No existing HTTP endpoint signatures change. The five mutation endpoints gain `await bus.publish(...)` calls after their DB commits — transparent to callers.
+
+One behavioural side-effect: `DELETE /todos/{id}/tags/{tag_id}` currently returns 204 without reading back the todo. To publish an `"updated"` event with the full post-mutation todo, the handler must add a DB read after the commit. Return value and HTTP status are unchanged.
+
+Similarly, `DELETE /todos/{todo_id}` must SELECT the full todo (with tags) before the DELETE statement so the `"deleted"` event can include the pre-deletion body.
+
+## Test plan
+
+New file `tests/test_websocket.py` — all async, using FastAPI `TestClient.websocket_connect`:
+
+1. `test_ws_rejects_missing_auth` — no `Authorization` header → upgrade rejected (WebSocketDisconnect / 403).
+2. `test_ws_rejects_invalid_token` — `Authorization: Bearer not.a.jwt` → rejected.
+3. `test_ws_rejects_expired_token` — forge a JWT with `exp` in the past → rejected.
+4. `test_ws_accepts_valid_token_and_sends_hello` — valid token → first frame is `{"type":"hello","user_id":<N>}`.
+5. `test_ws_receives_created_on_post` — open WS as user A; POST todo via HTTP as same user → WS receives `{"type":"created","todo":{...}}`.
+6. `test_ws_receives_updated_on_patch` — POST then PATCH → WS receives `created` then `updated`.
+7. `test_ws_receives_deleted_on_delete` — POST then DELETE → WS receives `deleted` with pre-delete todo body.
+8. `test_ws_isolates_by_user` — WS as user A; user B POSTs a todo → user A receives nothing (assert `receive_json` times out / raises before delivering data).
+9. `test_ws_receives_tag_events` — POST todo + POST tag + POST `/todos/{id}/tags` → WS receives `created` then `updated` (with tag list populated).
+10. `test_ws_cleanup_on_disconnect` — connect then close; assert `bus._subscribers.get(user_id, set())` is empty.
+
+All existing tests must continue to pass unchanged (no DB schema changes, no auth model changes, no existing endpoint return-value changes).
+
+## Risk justification
+
+Classified **high** because this PR introduces a new public API surface (the WebSocket endpoint) and new authentication/authorization logic (JWT validation on the WS upgrade path) — both appear explicitly in the risk rubric. The in-memory pub/sub adds stateful concurrency complexity as well.
+
+## Open questions
+
+1. Should the `decode_token_from_ws_headers` helper also verify that the user still exists in the DB (matching `get_current_user` behaviour), or is a valid unexpired JWT sufficient? The issue spec only calls `decode_token`, skipping the DB check. Recommend following the spec (JWT-only) for now and aligning with `get_current_user` in a follow-up if needed.
+2. The issue mentions close code `1011` for server-side errors in the prose, but the handler skeleton uses `1008` for auth rejection. The two codes serve different purposes (1008 = policy violation / auth; 1011 = internal server error). The change-set follows this split: use `1008` for auth failures, `1011` for unexpected exceptions in the event loop.
+3. `TestClient.websocket_connect` is synchronous; receiving events published by a concurrent HTTP request in the same test process requires care. The implementer should use `TestClient` for the HTTP mutations and the same client's WebSocket handle for receives, keeping both in the same thread via the `with websocket_connect(...) as ws:` context manager pattern.


### PR DESCRIPTION
## High-risk change-set for #28

This PR contains the Planner's change-set for a **high-risk** issue. The Implementer has **not** been dispatched.

**To proceed:** review `docs/change-sets/28.md`, make any corrections, then manually dispatch the Implementer:

```\ngh workflow run autoagent-implementer.yml -f issue_number=28 -f base_branch=main\n```