### PR TITLE
feat: add WebSocket /ws/todos streaming todo lifecycle events

### DIFF
--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -3,16 +3,18 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 import aiosqlite
-from fastapi import Depends, FastAPI, HTTPException, Query, Response
+from fastapi import Depends, FastAPI, HTTPException, Query, Response, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, EmailStr, Field
 
 from todo_api.auth import (
     JWT_EXPIRY_SECONDS,
     create_token,
+    decode_token_from_ws_headers,
     get_current_user,
     hash_password,
     verify_password,
 )
+from todo_api.events import bus
 from todo_api.db import (
     IntegrityError,
     _row_to_tag,
@@ -198,7 +200,9 @@ async def create_todo(
     )
     row = await cursor.fetchone()
     tags = await get_tags_for_todo(conn, row["id"])
-    return _row_to_todo(row, tags)
+    todo = _row_to_todo(row, tags)
+    await bus.publish(user_id, {"type": "created", "todo": todo.model_dump(mode="json")})
+    return todo
 
 
 @app.get("/todos")
@@ -294,7 +298,9 @@ async def patch_todo(
     )
     row = await cursor.fetchone()
     tags = await get_tags_for_todo(conn, row["id"])
-    return _row_to_todo(row, tags)
+    todo = _row_to_todo(row, tags)
+    await bus.publish(user_id, {"type": "updated", "todo": todo.model_dump(mode="json")})
+    return todo
 
 
 @app.delete("/todos/{todo_id}", status_code=204)
@@ -304,11 +310,18 @@ async def delete_todo(
     conn: aiosqlite.Connection = Depends(get_db),
 ) -> Response:
     cursor = await conn.execute(
-        "DELETE FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
+        "SELECT * FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    tags = await get_tags_for_todo(conn, row["id"])
+    pre_delete_todo = _row_to_todo(row, tags)
+    await conn.execute(
+        "DELETE FROM todos WHERE id = ?", (todo_id,)
     )
     await conn.commit()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="Not Found")
+    await bus.publish(user_id, {"type": "deleted", "todo": pre_delete_todo.model_dump(mode="json")})
     return Response(status_code=204)
 
 
@@ -392,7 +405,9 @@ async def assign_tags(
         )
     await conn.commit()
     tags = await get_tags_for_todo(conn, row["id"])
-    return _row_to_todo(row, tags)
+    todo = _row_to_todo(row, tags)
+    await bus.publish(user_id, {"type": "updated", "todo": todo.model_dump(mode="json")})
+    return todo
 
 
 @app.delete("/todos/{todo_id}/tags/{tag_id}", status_code=204)
@@ -415,4 +430,31 @@ async def remove_tag(
     await conn.commit()
     if cursor.rowcount == 0:
         raise HTTPException(status_code=404, detail="Not Found")
+    cursor = await conn.execute(
+        "SELECT * FROM todos WHERE id = ?", (todo_id,)
+    )
+    row = await cursor.fetchone()
+    tags = await get_tags_for_todo(conn, todo_id)
+    todo = _row_to_todo(row, tags)
+    await bus.publish(user_id, {"type": "updated", "todo": todo.model_dump(mode="json")})
     return Response(status_code=204)
+
+
+# --- WebSocket ---
+
+@app.websocket("/ws/todos")
+async def todos_stream(ws: WebSocket) -> None:
+    user_id = decode_token_from_ws_headers(ws)
+    await ws.accept()
+    await ws.send_json({"type": "hello", "user_id": user_id})
+    queue = bus.subscribe(user_id)
+    try:
+        while True:
+            event = await queue.get()
+            await ws.send_json(event)
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        await ws.close(code=1011, reason="internal error")
+    finally:
+        bus.unsubscribe(user_id, queue)

--- a/src/todo_api/auth.py
+++ b/src/todo_api/auth.py
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta, timezone
 
 import bcrypt
 import jwt
-from fastapi import Header, HTTPException
+from fastapi import Header, HTTPException, WebSocket, status
+from fastapi.exceptions import WebSocketException
 
 from todo_api.db import get_connection
 
@@ -60,3 +61,13 @@ async def get_current_user(authorization: str | None = Header(default=None)) -> 
     if row is None:
         raise HTTPException(status_code=401, detail="Invalid or missing token")
     return user_id
+
+
+def decode_token_from_ws_headers(ws: WebSocket) -> int:
+    auth = ws.headers.get("authorization")
+    if not auth or not auth.startswith("Bearer "):
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+    try:
+        return decode_token(auth.removeprefix("Bearer "))
+    except (jwt.InvalidTokenError, KeyError, ValueError):
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)

--- a/src/todo_api/events.py
+++ b/src/todo_api/events.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+
+
+class EventBus:
+    def __init__(self) -> None:
+        self._subscribers: dict[int, set[asyncio.Queue[dict]]] = {}
+
+    def subscribe(self, user_id: int) -> asyncio.Queue[dict]:
+        queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)
+        self._subscribers.setdefault(user_id, set()).add(queue)
+        return queue
+
+    def unsubscribe(self, user_id: int, queue: asyncio.Queue[dict]) -> None:
+        subs = self._subscribers.get(user_id)
+        if subs:
+            subs.discard(queue)
+            if not subs:
+                del self._subscribers[user_id]
+
+    async def publish(self, user_id: int, event: dict) -> None:
+        for queue in self._subscribers.get(user_id, set()).copy():
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                # Drop event to avoid unbounded memory growth.
+                pass
+
+    def reset(self) -> None:
+        self._subscribers.clear()
+
+    def subscriber_count(self, user_id: int) -> int:
+        return len(self._subscribers.get(user_id, set()))
+
+
+bus = EventBus()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from todo_api import db as db_module
 from todo_api import rate_limit
+from todo_api.events import bus
 from todo_api.app import app
 
 
@@ -18,6 +19,7 @@ async def isolated_state(tmp_path, monkeypatch):
     finally:
         await conn.close()
     rate_limit.reset_buckets()
+    bus.reset()
 
 
 @pytest.fixture

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,161 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from todo_api.app import app
+from todo_api.auth import JWT_ALGORITHM, JWT_SECRET
+from todo_api.events import bus
+
+
+def _register_and_login(client: TestClient) -> tuple[int, dict[str, str]]:
+    email = f"ws-{uuid.uuid4()}@example.com"
+    reg = client.post("/auth/register", json={"email": email, "password": "testpass123"})
+    user_id = reg.json()["id"]
+    resp = client.post("/auth/login", json={"email": email, "password": "testpass123"})
+    token = resp.json()["access_token"]
+    return user_id, {"Authorization": f"Bearer {token}"}
+
+
+def test_ws_rejects_missing_auth():
+    client = TestClient(app)
+    with pytest.raises(Exception):
+        with client.websocket_connect("/ws/todos"):
+            pass
+
+
+def test_ws_rejects_invalid_token():
+    client = TestClient(app)
+    with pytest.raises(Exception):
+        with client.websocket_connect(
+            "/ws/todos", headers={"Authorization": "Bearer not.a.jwt"}
+        ):
+            pass
+
+
+def test_ws_rejects_expired_token():
+    client = TestClient(app)
+    payload = {
+        "sub": "1",
+        "exp": datetime.now(timezone.utc) - timedelta(seconds=60),
+    }
+    expired_token = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    with pytest.raises(Exception):
+        with client.websocket_connect(
+            "/ws/todos", headers={"Authorization": f"Bearer {expired_token}"}
+        ):
+            pass
+
+
+def test_ws_accepts_valid_token_and_sends_hello():
+    client = TestClient(app)
+    user_id, headers = _register_and_login(client)
+    with client.websocket_connect("/ws/todos", headers=headers) as ws:
+        hello = ws.receive_json()
+        assert hello == {"type": "hello", "user_id": user_id}
+
+
+def test_ws_receives_created_on_post():
+    client = TestClient(app)
+    user_id, headers = _register_and_login(client)
+    with client.websocket_connect("/ws/todos", headers=headers) as ws:
+        ws.receive_json()  # hello
+
+        resp = client.post("/todos", json={"title": "ws test"}, headers=headers)
+        assert resp.status_code == 201
+        todo = resp.json()
+
+        event = ws.receive_json()
+        assert event["type"] == "created"
+        assert event["todo"]["id"] == todo["id"]
+        assert event["todo"]["title"] == "ws test"
+
+
+def test_ws_receives_updated_on_patch():
+    client = TestClient(app)
+    user_id, headers = _register_and_login(client)
+    with client.websocket_connect("/ws/todos", headers=headers) as ws:
+        ws.receive_json()  # hello
+
+        resp = client.post("/todos", json={"title": "original"}, headers=headers)
+        todo_id = resp.json()["id"]
+        ws.receive_json()  # created event
+
+        client.patch(f"/todos/{todo_id}", json={"title": "updated"}, headers=headers)
+
+        event = ws.receive_json()
+        assert event["type"] == "updated"
+        assert event["todo"]["title"] == "updated"
+
+
+def test_ws_receives_deleted_on_delete():
+    client = TestClient(app)
+    user_id, headers = _register_and_login(client)
+    with client.websocket_connect("/ws/todos", headers=headers) as ws:
+        ws.receive_json()  # hello
+
+        resp = client.post("/todos", json={"title": "to-delete"}, headers=headers)
+        todo = resp.json()
+        ws.receive_json()  # created event
+
+        client.delete(f"/todos/{todo['id']}", headers=headers)
+
+        event = ws.receive_json()
+        assert event["type"] == "deleted"
+        assert event["todo"]["id"] == todo["id"]
+        assert event["todo"]["title"] == "to-delete"
+
+
+def test_ws_isolates_by_user():
+    client = TestClient(app)
+    _, headers_a = _register_and_login(client)
+    _, headers_b = _register_and_login(client)
+
+    with client.websocket_connect("/ws/todos", headers=headers_a) as ws:
+        ws.receive_json()  # hello
+
+        # User B creates a todo — user A should NOT see it
+        client.post("/todos", json={"title": "b's todo"}, headers=headers_b)
+
+        # User A creates a todo — user A SHOULD see it
+        client.post("/todos", json={"title": "a's todo"}, headers=headers_a)
+
+        event = ws.receive_json()
+        assert event["type"] == "created"
+        assert event["todo"]["title"] == "a's todo"
+
+
+def test_ws_receives_tag_events():
+    client = TestClient(app)
+    user_id, headers = _register_and_login(client)
+
+    tag_resp = client.post("/tags", json={"name": "urgent"}, headers=headers)
+    tag_id = tag_resp.json()["id"]
+
+    with client.websocket_connect("/ws/todos", headers=headers) as ws:
+        ws.receive_json()  # hello
+
+        resp = client.post("/todos", json={"title": "tagged"}, headers=headers)
+        todo_id = resp.json()["id"]
+        created = ws.receive_json()
+        assert created["type"] == "created"
+
+        client.post(
+            f"/todos/{todo_id}/tags", json={"tag_ids": [tag_id]}, headers=headers
+        )
+        updated = ws.receive_json()
+        assert updated["type"] == "updated"
+        assert any(t["id"] == tag_id for t in updated["todo"]["tags"])
+
+
+def test_ws_cleanup_on_disconnect():
+    client = TestClient(app)
+    user_id, headers = _register_and_login(client)
+
+    with client.websocket_connect("/ws/todos", headers=headers) as ws:
+        ws.receive_json()  # hello
+        assert bus.subscriber_count(user_id) == 1
+
+    assert bus.subscriber_count(user_id) == 0


### PR DESCRIPTION
## Summary

- Adds `WS /ws/todos` endpoint that authenticates via JWT on the upgrade request and streams per-user todo lifecycle events (`created`, `updated`, `deleted`) in real time
- New `EventBus` in-memory pub/sub module (`src/todo_api/events.py`) fans out events to all open sockets for a given `user_id`
- Wires `bus.publish(...)` into `POST /todos`, `PATCH /todos/{id}`, `DELETE /todos/{id}`, `POST /todos/{id}/tags`, and `DELETE /todos/{id}/tags/{tag_id}` — events are published after DB commit

Closes #28

## Changes

| File | Change |
|---|---|
| `src/todo_api/events.py` | **New** — `EventBus` class with subscribe/unsubscribe/publish + module-level `bus` singleton |
| `src/todo_api/auth.py` | Add `decode_token_from_ws_headers(ws)` helper raising `WebSocketException(1008)` on bad/missing JWT |
| `src/todo_api/app.py` | Add `@app.websocket("/ws/todos")` handler; wire `bus.publish` into 5 mutation endpoints; pre-fetch todo before DELETE for event payload |
| `tests/conftest.py` | Reset `bus` between tests |
| `tests/test_websocket.py` | **New** — 10 tests covering auth rejection, hello frame, created/updated/deleted events, user isolation, tag events, cleanup on disconnect |

## Test plan

- [x] `pytest -q` passes — 109 tests (99 prior + 10 new)
- [x] `grep -E "@app.websocket" src/todo_api/app.py` shows exactly 1 match
- [x] `grep -E "bus.publish" src/todo_api/app.py` shows 5 matches (POST, PATCH, DELETE, tag assign, tag remove)
- [x] Auth rejection: missing header, invalid token, expired token all rejected before upgrade
- [x] Hello frame sent on connect with correct `user_id`
- [x] Created/updated/deleted events received for respective mutations
- [x] User isolation: user A does not receive user B's events
- [x] Tag assign triggers `updated` event with tags populated
- [x] Subscriber cleanup verified after disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)