### PR TITLE
feat: migrate from SQLite+aiosqlite to PostgreSQL+asyncpg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,17 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pydantic[email]>=2.6",
     "bcrypt>=4.0",
     "pyjwt>=2.8",
-    "aiosqlite>=0.19",
+    "asyncpg>=0.29",
 ]
 
 [project.optional-dependencies]

--- a/src/todo_api/app.py
+++ b/src/todo_api/app.py
@@ -2,7 +2,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
-import aiosqlite
+import asyncpg
 from fastapi import Depends, FastAPI, HTTPException, Query, Response, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, EmailStr, Field
 
@@ -16,10 +16,12 @@ from todo_api.auth import (
 )
 from todo_api.events import bus
 from todo_api.db import (
-    IntegrityError,
+    _delete_affected,
     _row_to_tag,
     _row_to_todo,
-    get_connection,
+    close_pool,
+    get_db,
+    get_pool,
     get_tags_for_todo,
     init_schema,
 )
@@ -28,21 +30,14 @@ from todo_api.rate_limit import anon_rate_limit, authed_rate_limit
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    conn = await get_connection()
-    await init_schema(conn)
-    await conn.close()
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        await init_schema(conn)
     yield
+    await close_pool()
 
 
 app = FastAPI(lifespan=lifespan)
-
-
-async def get_db() -> AsyncIterator[aiosqlite.Connection]:
-    conn = await get_connection()
-    try:
-        yield conn
-    finally:
-        await conn.close()
 
 
 # --- Auth models ---
@@ -126,32 +121,30 @@ class TodoStats(BaseModel):
 async def register(
     body: UserCreate,
     _: str = Depends(anon_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> UserResponse:
     now = datetime.now(timezone.utc)
     hashed = hash_password(body.password)
     try:
-        cursor = await conn.execute(
-            "INSERT INTO users (email, password_hash, created_at) VALUES (?, ?, ?)",
-            (body.email, hashed, now.isoformat()),
+        row = await conn.fetchrow(
+            "INSERT INTO users (email, password_hash, created_at) "
+            "VALUES (LOWER($1), $2, $3) RETURNING id, email, created_at",
+            body.email, hashed, now,
         )
-        await conn.commit()
-    except IntegrityError:
+    except asyncpg.UniqueViolationError:
         raise HTTPException(status_code=409, detail="Email already registered")
-    user_id = cursor.lastrowid
-    return UserResponse(id=user_id, email=body.email, created_at=now)
+    return UserResponse(id=row["id"], email=row["email"], created_at=row["created_at"])
 
 
 @app.post("/auth/login")
 async def login(
     body: LoginRequest,
     _: str = Depends(anon_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> LoginResponse:
-    cursor = await conn.execute(
-        "SELECT * FROM users WHERE email = ?", (body.email,)
+    row = await conn.fetchrow(
+        "SELECT * FROM users WHERE LOWER(email) = LOWER($1)", body.email,
     )
-    row = await cursor.fetchone()
     if row is None or not verify_password(body.password, row["password_hash"]):
         raise HTTPException(status_code=401, detail="Invalid credentials")
     token = create_token(row["id"])
@@ -163,14 +156,13 @@ async def login(
 @app.get("/auth/me")
 async def get_me(
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> UserResponse:
-    cursor = await conn.execute("SELECT * FROM users WHERE id = ?", (user_id,))
-    row = await cursor.fetchone()
+    row = await conn.fetchrow("SELECT * FROM users WHERE id = $1", user_id)
     return UserResponse(
         id=row["id"],
         email=row["email"],
-        created_at=datetime.fromisoformat(row["created_at"]),
+        created_at=row["created_at"],
     )
 
 
@@ -187,18 +179,14 @@ async def health() -> dict[str, str]:
 async def create_todo(
     body: TodoCreate,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Todo:
     now = datetime.now(timezone.utc)
-    cursor = await conn.execute(
-        "INSERT INTO todos (user_id, title, done, created_at) VALUES (?, ?, 0, ?)",
-        (user_id, body.title, now.isoformat()),
+    row = await conn.fetchrow(
+        "INSERT INTO todos (user_id, title, done, created_at) "
+        "VALUES ($1, $2, FALSE, $3) RETURNING *",
+        user_id, body.title, now,
     )
-    await conn.commit()
-    cursor = await conn.execute(
-        "SELECT * FROM todos WHERE id = ?", (cursor.lastrowid,)
-    )
-    row = await cursor.fetchone()
     tags = await get_tags_for_todo(conn, row["id"])
     todo = _row_to_todo(row, tags)
     await bus.publish(user_id, {"type": "created", "todo": todo.model_dump(mode="json")})
@@ -208,37 +196,54 @@ async def create_todo(
 @app.get("/todos")
 async def list_todos(
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
     done: bool | None = Query(default=None),
     tag_ids: list[int] | None = Query(default=None),
 ) -> TodoList:
-    done_val = int(done) if done is not None else None
-    has_tag_filter = int(bool(tag_ids))
-    placeholders = ",".join("?" * len(tag_ids)) if tag_ids else "NULL"
-    tag_params = list(tag_ids) if tag_ids else []
+    has_tag_filter = bool(tag_ids)
+    tag_list = tag_ids if tag_ids else []
 
-    cursor = await conn.execute(
+    params: list[object] = [user_id]
+    idx = 2
+
+    if done is not None:
+        done_clause = f"AND t.done = ${idx}"
+        params.append(done)
+        idx += 1
+    else:
+        done_clause = ""
+
+    if has_tag_filter:
+        placeholders = ", ".join(f"${idx + i}" for i in range(len(tag_list)))
+        tag_clause = f"AND tt.tag_id IN ({placeholders})"
+        params.extend(tag_list)
+        idx += len(tag_list)
+    else:
+        tag_clause = ""
+
+    params.extend([limit, offset])
+    limit_idx = idx
+    offset_idx = idx + 1
+
+    rows = await conn.fetch(
         "SELECT DISTINCT t.* FROM todos t "
         "LEFT JOIN todo_tags tt ON tt.todo_id = t.id "
-        f"WHERE t.user_id = ? "
-        f"  AND (? IS NULL OR t.done = ?) "
-        f"  AND (? = 0 OR tt.tag_id IN ({placeholders})) "
-        "ORDER BY t.id DESC LIMIT ? OFFSET ?",
-        [user_id, done_val, done_val, has_tag_filter] + tag_params + [limit, offset],
+        f"WHERE t.user_id = $1 {done_clause} {tag_clause} "
+        f"ORDER BY t.id DESC LIMIT ${limit_idx} OFFSET ${offset_idx}",
+        *params,
     )
-    rows = await cursor.fetchall()
-    cursor = await conn.execute(
-        "SELECT COUNT(DISTINCT t.id) FROM todos t "
+
+    count_params = params[:-2]
+    count_row = await conn.fetchrow(
+        "SELECT COUNT(DISTINCT t.id) AS cnt FROM todos t "
         "LEFT JOIN todo_tags tt ON tt.todo_id = t.id "
-        f"WHERE t.user_id = ? "
-        f"  AND (? IS NULL OR t.done = ?) "
-        f"  AND (? = 0 OR tt.tag_id IN ({placeholders}))",
-        [user_id, done_val, done_val, has_tag_filter] + tag_params,
+        f"WHERE t.user_id = $1 {done_clause} {tag_clause}",
+        *count_params,
     )
-    total_row = await cursor.fetchone()
-    total = total_row[0]
+    total = count_row["cnt"]
+
     items = []
     for r in rows:
         tags = await get_tags_for_todo(conn, r["id"])
@@ -249,15 +254,16 @@ async def list_todos(
 @app.get("/todos/stats")
 async def get_stats(
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> TodoStats:
-    cursor = await conn.execute(
-        "SELECT COUNT(*) AS total, SUM(done) AS done FROM todos WHERE user_id = ?",
-        (user_id,),
+    row = await conn.fetchrow(
+        "SELECT COUNT(*) AS total, "
+        "COUNT(*) FILTER (WHERE done) AS done "
+        "FROM todos WHERE user_id = $1",
+        user_id,
     )
-    row = await cursor.fetchone()
     total = row["total"]
-    done_count = row["done"] or 0
+    done_count = row["done"]
     return TodoStats(total=total, done=done_count, pending=total - done_count)
 
 
@@ -265,12 +271,11 @@ async def get_stats(
 async def get_todo(
     todo_id: int,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Todo:
-    cursor = await conn.execute(
-        "SELECT * FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM todos WHERE id = $1 AND user_id = $2", todo_id, user_id,
     )
-    row = await cursor.fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="Not Found")
     tags = await get_tags_for_todo(conn, row["id"])
@@ -282,21 +287,19 @@ async def patch_todo(
     todo_id: int,
     body: PatchTodo,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Todo:
-    done_val = int(body.done) if body.done is not None else None
-    cursor = await conn.execute(
-        "UPDATE todos SET title = COALESCE(?, title), done = COALESCE(?, done) "
-        "WHERE id = ? AND user_id = ?",
-        (body.title, done_val, todo_id, user_id),
+    affected = await _delete_affected(
+        conn,
+        "UPDATE todos SET title = COALESCE($1, title), done = COALESCE($2, done) "
+        "WHERE id = $3 AND user_id = $4",
+        body.title, body.done, todo_id, user_id,
     )
-    await conn.commit()
-    if cursor.rowcount == 0:
+    if affected == 0:
         raise HTTPException(status_code=404, detail="Not Found")
-    cursor = await conn.execute(
-        "SELECT * FROM todos WHERE id = ?", (todo_id,)
+    row = await conn.fetchrow(
+        "SELECT * FROM todos WHERE id = $1", todo_id,
     )
-    row = await cursor.fetchone()
     tags = await get_tags_for_todo(conn, row["id"])
     todo = _row_to_todo(row, tags)
     await bus.publish(user_id, {"type": "updated", "todo": todo.model_dump(mode="json")})
@@ -307,20 +310,16 @@ async def patch_todo(
 async def delete_todo(
     todo_id: int,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Response:
-    cursor = await conn.execute(
-        "SELECT * FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM todos WHERE id = $1 AND user_id = $2", todo_id, user_id,
     )
-    row = await cursor.fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="Not Found")
     tags = await get_tags_for_todo(conn, row["id"])
     pre_delete_todo = _row_to_todo(row, tags)
-    await conn.execute(
-        "DELETE FROM todos WHERE id = ?", (todo_id,)
-    )
-    await conn.commit()
+    await conn.execute("DELETE FROM todos WHERE id = $1", todo_id)
     await bus.publish(user_id, {"type": "deleted", "todo": pre_delete_todo.model_dump(mode="json")})
     return Response(status_code=204)
 
@@ -331,31 +330,26 @@ async def delete_todo(
 async def create_tag(
     body: TagCreate,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Tag:
     try:
-        cursor = await conn.execute(
-            "INSERT INTO tags (user_id, name) VALUES (?, ?)", (user_id, body.name)
+        row = await conn.fetchrow(
+            "INSERT INTO tags (user_id, name) VALUES ($1, $2) RETURNING id, name",
+            user_id, body.name,
         )
-        await conn.commit()
-    except IntegrityError:
+    except asyncpg.UniqueViolationError:
         raise HTTPException(status_code=409, detail="Tag already exists")
-    cursor = await conn.execute(
-        "SELECT * FROM tags WHERE id = ?", (cursor.lastrowid,)
-    )
-    row = await cursor.fetchone()
     return _row_to_tag(row)
 
 
 @app.get("/tags")
 async def list_tags(
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> TagList:
-    cursor = await conn.execute(
-        "SELECT * FROM tags WHERE user_id = ? ORDER BY id DESC", (user_id,)
+    rows = await conn.fetch(
+        "SELECT * FROM tags WHERE user_id = $1 ORDER BY id DESC", user_id,
     )
-    rows = await cursor.fetchall()
     return TagList(items=[_row_to_tag(r) for r in rows], total=len(rows))
 
 
@@ -363,13 +357,13 @@ async def list_tags(
 async def delete_tag(
     tag_id: int,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Response:
-    cursor = await conn.execute(
-        "DELETE FROM tags WHERE id = ? AND user_id = ?", (tag_id, user_id)
+    affected = await _delete_affected(
+        conn,
+        "DELETE FROM tags WHERE id = $1 AND user_id = $2", tag_id, user_id,
     )
-    await conn.commit()
-    if cursor.rowcount == 0:
+    if affected == 0:
         raise HTTPException(status_code=404, detail="Not Found")
     return Response(status_code=204)
 
@@ -381,29 +375,27 @@ async def assign_tags(
     todo_id: int,
     body: TagAssign,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Todo:
-    cursor = await conn.execute(
-        "SELECT * FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM todos WHERE id = $1 AND user_id = $2", todo_id, user_id,
     )
-    row = await cursor.fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="Not Found")
     for tid in body.tag_ids:
-        cursor = await conn.execute(
-            "SELECT id FROM tags WHERE id = ? AND user_id = ?", (tid, user_id)
+        exists = await conn.fetchrow(
+            "SELECT id FROM tags WHERE id = $1 AND user_id = $2", tid, user_id,
         )
-        exists = await cursor.fetchone()
         if exists is None:
             raise HTTPException(
                 status_code=400, detail=f"Unknown tag_id: {tid}"
             )
     for tid in body.tag_ids:
         await conn.execute(
-            "INSERT OR IGNORE INTO todo_tags (todo_id, tag_id) VALUES (?, ?)",
-            (todo_id, tid),
+            "INSERT INTO todo_tags (todo_id, tag_id) VALUES ($1, $2) "
+            "ON CONFLICT DO NOTHING",
+            todo_id, tid,
         )
-    await conn.commit()
     tags = await get_tags_for_todo(conn, row["id"])
     todo = _row_to_todo(row, tags)
     await bus.publish(user_id, {"type": "updated", "todo": todo.model_dump(mode="json")})
@@ -415,25 +407,23 @@ async def remove_tag(
     todo_id: int,
     tag_id: int,
     user_id: int = Depends(authed_rate_limit),
-    conn: aiosqlite.Connection = Depends(get_db),
+    conn: asyncpg.Connection = Depends(get_db),
 ) -> Response:
-    cursor = await conn.execute(
-        "SELECT id FROM todos WHERE id = ? AND user_id = ?", (todo_id, user_id)
+    todo_row = await conn.fetchrow(
+        "SELECT id FROM todos WHERE id = $1 AND user_id = $2", todo_id, user_id,
     )
-    todo_row = await cursor.fetchone()
     if todo_row is None:
         raise HTTPException(status_code=404, detail="Not Found")
-    cursor = await conn.execute(
-        "DELETE FROM todo_tags WHERE todo_id = ? AND tag_id = ?",
-        (todo_id, tag_id),
+    affected = await _delete_affected(
+        conn,
+        "DELETE FROM todo_tags WHERE todo_id = $1 AND tag_id = $2",
+        todo_id, tag_id,
     )
-    await conn.commit()
-    if cursor.rowcount == 0:
+    if affected == 0:
         raise HTTPException(status_code=404, detail="Not Found")
-    cursor = await conn.execute(
-        "SELECT * FROM todos WHERE id = ?", (todo_id,)
+    row = await conn.fetchrow(
+        "SELECT * FROM todos WHERE id = $1", todo_id,
     )
-    row = await cursor.fetchone()
     tags = await get_tags_for_todo(conn, todo_id)
     todo = _row_to_todo(row, tags)
     await bus.publish(user_id, {"type": "updated", "todo": todo.model_dump(mode="json")})

--- a/src/todo_api/auth.py
+++ b/src/todo_api/auth.py
@@ -9,7 +9,7 @@ import jwt
 from fastapi import Header, HTTPException, WebSocket, status
 from fastapi.exceptions import WebSocketException
 
-from todo_api.db import get_connection
+from todo_api.db import get_pool
 
 _TESTING = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
 
@@ -52,12 +52,8 @@ async def get_current_user(authorization: str | None = Header(default=None)) -> 
         user_id = decode_token(token)
     except (jwt.InvalidTokenError, KeyError, ValueError):
         raise HTTPException(status_code=401, detail="Invalid or missing token")
-    conn = await get_connection()
-    try:
-        cursor = await conn.execute("SELECT id FROM users WHERE id = ?", (user_id,))
-        row = await cursor.fetchone()
-    finally:
-        await conn.close()
+    pool = await get_pool()
+    row = await pool.fetchrow("SELECT id FROM users WHERE id = $1", user_id)
     if row is None:
         raise HTTPException(status_code=401, detail="Invalid or missing token")
     return user_id

--- a/src/todo_api/db.py
+++ b/src/todo_api/db.py
@@ -1,63 +1,91 @@
 from __future__ import annotations
 
+import asyncio
 import os
-import sqlite3
-from datetime import datetime
-from pathlib import Path
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
-import aiosqlite
+import asyncpg
 
 if TYPE_CHECKING:
     from todo_api.app import Tag, Todo
 
-DB_PATH: Path = Path(os.environ.get("TODO_DB_PATH", ":memory:"))
+_TESTING = "PYTEST_CURRENT_TEST" in os.environ
 
-IntegrityError = sqlite3.IntegrityError
+DATABASE_URL: str = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/test" if _TESTING else "",
+)
+
+if not DATABASE_URL and not _TESTING:
+    raise RuntimeError("DATABASE_URL environment variable is required")
+
+_pools: dict[int, asyncpg.Pool] = {}
 
 
-async def get_connection() -> aiosqlite.Connection:
-    conn = await aiosqlite.connect(DB_PATH, detect_types=sqlite3.PARSE_DECLTYPES)
-    conn.row_factory = aiosqlite.Row
-    await conn.execute("PRAGMA foreign_keys=ON")
-    return conn
+async def get_pool() -> asyncpg.Pool:
+    loop = asyncio.get_running_loop()
+    loop_id = id(loop)
+    pool = _pools.get(loop_id)
+    if pool is None or pool._closed:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=10)
+        _pools[loop_id] = pool
+    return pool
 
 
-async def init_schema(conn: aiosqlite.Connection) -> None:
+async def close_pool() -> None:
+    loop = asyncio.get_running_loop()
+    loop_id = id(loop)
+    pool = _pools.pop(loop_id, None)
+    if pool is not None:
+        await pool.close()
+
+
+def terminate_all_pools() -> None:
+    for pool in list(_pools.values()):
+        if not pool._closed:
+            try:
+                pool.terminate()
+            except Exception:
+                pass
+    _pools.clear()
+
+
+async def init_schema(conn: asyncpg.Connection) -> None:
     await conn.execute(
         "CREATE TABLE IF NOT EXISTS users ("
-        "    id            INTEGER PRIMARY KEY AUTOINCREMENT,"
-        "    email         TEXT    NOT NULL UNIQUE COLLATE NOCASE,"
-        "    password_hash TEXT    NOT NULL,"
-        "    created_at    TEXT    NOT NULL"
+        "    id            BIGSERIAL PRIMARY KEY,"
+        "    email         TEXT NOT NULL UNIQUE,"
+        "    password_hash TEXT NOT NULL,"
+        "    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()"
         ")"
     )
     await conn.execute(
         "CREATE TABLE IF NOT EXISTS todos ("
-        "    id         INTEGER PRIMARY KEY AUTOINCREMENT,"
-        "    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,"
-        "    title      TEXT    NOT NULL,"
-        "    done       INTEGER NOT NULL DEFAULT 0,"
-        "    created_at TEXT    NOT NULL"
+        "    id         BIGSERIAL PRIMARY KEY,"
+        "    user_id    BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,"
+        "    title      TEXT NOT NULL,"
+        "    done       BOOLEAN NOT NULL DEFAULT FALSE,"
+        "    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"
         ")"
     )
     await conn.execute(
         "CREATE TABLE IF NOT EXISTS tags ("
-        "    id      INTEGER PRIMARY KEY AUTOINCREMENT,"
-        "    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,"
-        "    name    TEXT    NOT NULL COLLATE NOCASE,"
-        "    UNIQUE(user_id, name) ON CONFLICT ABORT"
+        "    id      BIGSERIAL PRIMARY KEY,"
+        "    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,"
+        "    name    TEXT NOT NULL"
         ")"
     )
     await conn.execute(
         "CREATE TABLE IF NOT EXISTS todo_tags ("
-        "    todo_id INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,"
-        "    tag_id  INTEGER NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,"
+        "    todo_id BIGINT NOT NULL REFERENCES todos(id) ON DELETE CASCADE,"
+        "    tag_id  BIGINT NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,"
         "    PRIMARY KEY (todo_id, tag_id)"
         ")"
     )
     await conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_todo_tags_tag ON todo_tags(tag_id)"
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_user_lower_name "
+        "ON tags (user_id, LOWER(name))"
     )
     await conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_todos_user ON todos(user_id)"
@@ -65,33 +93,44 @@ async def init_schema(conn: aiosqlite.Connection) -> None:
     await conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tags_user ON tags(user_id)"
     )
-    await conn.commit()
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_todo_tags_tag ON todo_tags(tag_id)"
+    )
 
 
-def _row_to_tag(row: aiosqlite.Row) -> Tag:
+async def get_db() -> AsyncIterator[asyncpg.Connection]:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        yield conn
+
+
+def _row_to_tag(row: asyncpg.Record) -> Tag:
     from todo_api.app import Tag
 
     return Tag(id=row["id"], name=row["name"])
 
 
-async def get_tags_for_todo(conn: aiosqlite.Connection, todo_id: int) -> list[Tag]:
-    cursor = await conn.execute(
+async def get_tags_for_todo(conn: asyncpg.Connection, todo_id: int) -> list[Tag]:
+    rows = await conn.fetch(
         "SELECT t.id, t.name FROM tags t "
         "JOIN todo_tags tt ON tt.tag_id = t.id "
-        "WHERE tt.todo_id = ? ORDER BY t.id",
-        (todo_id,),
+        "WHERE tt.todo_id = $1 ORDER BY t.id",
+        todo_id,
     )
-    rows = await cursor.fetchall()
     return [_row_to_tag(r) for r in rows]
 
 
-def _row_to_todo(row: aiosqlite.Row, tags: list[Tag] | None = None) -> Todo:
+def _row_to_todo(row: asyncpg.Record, tags: list[Tag] | None = None) -> Todo:
     from todo_api.app import Todo
 
     return Todo(
         id=row["id"],
         title=row["title"],
-        done=bool(row["done"]),
-        created_at=datetime.fromisoformat(row["created_at"]),
+        done=row["done"],
+        created_at=row["created_at"],
         tags=tags if tags is not None else [],
     )
+
+
+async def _delete_affected(conn: asyncpg.Connection, sql: str, *args: object) -> int:
+    return int((await conn.execute(sql, *args)).split()[-1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import uuid
 
+import asyncpg
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
@@ -11,13 +12,26 @@ from todo_api.app import app
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def isolated_state(tmp_path, monkeypatch):
-    monkeypatch.setattr(db_module, "DB_PATH", tmp_path / "test.db")
-    conn = await db_module.get_connection()
+async def isolated_state():
+    db_module.terminate_all_pools()
+
+    conn = await asyncpg.connect(db_module.DATABASE_URL)
     try:
+        has_tables = await conn.fetchval(
+            "SELECT EXISTS ("
+            "  SELECT FROM information_schema.tables "
+            "  WHERE table_schema = 'public' AND table_name = 'users'"
+            ")"
+        )
+        if has_tables:
+            await conn.execute(
+                "TRUNCATE TABLE todo_tags, tags, todos, users "
+                "RESTART IDENTITY CASCADE"
+            )
         await db_module.init_schema(conn)
     finally:
         await conn.close()
+
     rate_limit.reset_buckets()
     bus.reset()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -116,14 +116,10 @@ async def test_password_is_bcrypt_hashed_in_db() -> None:
     email = f"hash-{uuid.uuid4()}@example.com"
     password = "testpass123"
     _register(email, password)
-    conn = await db_module.get_connection()
-    try:
-        cursor = await conn.execute(
-            "SELECT password_hash FROM users WHERE email = ?", (email,)
-        )
-        row = await cursor.fetchone()
-    finally:
-        await conn.close()
+    pool = await db_module.get_pool()
+    row = await pool.fetchrow(
+        "SELECT password_hash FROM users WHERE LOWER(email) = LOWER($1)", email,
+    )
     assert row is not None
     assert row["password_hash"].startswith("$2b$")
     assert row["password_hash"] != password

--- a/tests/test_auth_isolation.py
+++ b/tests/test_auth_isolation.py
@@ -94,23 +94,19 @@ async def test_deleting_user_cascades_todos_and_tags() -> None:
     _create_todo("t2", h)
     _create_tag("tag1", h)
 
-    conn = await db_module.get_connection()
-    try:
-        cursor = await conn.execute("SELECT id FROM users ORDER BY id DESC LIMIT 1")
-        user_row = await cursor.fetchone()
+    pool = await db_module.get_pool()
+    async with pool.acquire() as conn:
+        user_row = await conn.fetchrow("SELECT id FROM users ORDER BY id DESC LIMIT 1")
         user_id = user_row["id"]
 
-        cursor = await conn.execute("SELECT COUNT(*) FROM todos WHERE user_id = ?", (user_id,))
-        assert (await cursor.fetchone())[0] == 2
-        cursor = await conn.execute("SELECT COUNT(*) FROM tags WHERE user_id = ?", (user_id,))
-        assert (await cursor.fetchone())[0] == 1
+        row = await conn.fetchrow("SELECT COUNT(*) AS cnt FROM todos WHERE user_id = $1", user_id)
+        assert row["cnt"] == 2
+        row = await conn.fetchrow("SELECT COUNT(*) AS cnt FROM tags WHERE user_id = $1", user_id)
+        assert row["cnt"] == 1
 
-        await conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
-        await conn.commit()
+        await conn.execute("DELETE FROM users WHERE id = $1", user_id)
 
-        cursor = await conn.execute("SELECT COUNT(*) FROM todos WHERE user_id = ?", (user_id,))
-        assert (await cursor.fetchone())[0] == 0
-        cursor = await conn.execute("SELECT COUNT(*) FROM tags WHERE user_id = ?", (user_id,))
-        assert (await cursor.fetchone())[0] == 0
-    finally:
-        await conn.close()
+        row = await conn.fetchrow("SELECT COUNT(*) AS cnt FROM todos WHERE user_id = $1", user_id)
+        assert row["cnt"] == 0
+        row = await conn.fetchrow("SELECT COUNT(*) AS cnt FROM tags WHERE user_id = $1", user_id)
+        assert row["cnt"] == 0

--- a/tests/test_rate_limit_authed.py
+++ b/tests/test_rate_limit_authed.py
@@ -16,18 +16,29 @@ def _make_user() -> dict:
     return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
 
+def _frozen_consume(fixed_time: float = 0.0):
+    original = rate_limit.TokenBucket.consume
+
+    def wrapper(self, n=1, now=None):
+        return original(self, n, now=fixed_time)
+
+    return wrapper
+
+
 def test_authed_user_gets_60_requests_per_minute() -> None:
     headers = _make_user()
-    for i in range(60):
-        resp = client.get("/todos", headers=headers)
-        assert resp.status_code == 200, f"Request {i+1} failed with {resp.status_code}"
+    with patch.object(rate_limit.TokenBucket, "consume", _frozen_consume()):
+        for i in range(60):
+            resp = client.get("/todos", headers=headers)
+            assert resp.status_code == 200, f"Request {i+1} failed with {resp.status_code}"
 
 
 def test_authed_user_hits_429_on_61st() -> None:
     headers = _make_user()
-    for _ in range(60):
-        client.get("/todos", headers=headers)
-    resp = client.get("/todos", headers=headers)
+    with patch.object(rate_limit.TokenBucket, "consume", _frozen_consume()):
+        for _ in range(60):
+            client.get("/todos", headers=headers)
+        resp = client.get("/todos", headers=headers)
     assert resp.status_code == 429
     assert "Retry-After" in resp.headers
     assert resp.headers["Retry-After"].isdigit()
@@ -36,17 +47,19 @@ def test_authed_user_hits_429_on_61st() -> None:
 def test_two_users_have_independent_buckets() -> None:
     headers_a = _make_user()
     headers_b = _make_user()
-    for _ in range(60):
-        client.get("/todos", headers=headers_a)
-    assert client.get("/todos", headers=headers_a).status_code == 429
-    assert client.get("/todos", headers=headers_b).status_code == 200
+    with patch.object(rate_limit.TokenBucket, "consume", _frozen_consume()):
+        for _ in range(60):
+            client.get("/todos", headers=headers_a)
+        assert client.get("/todos", headers=headers_a).status_code == 429
+        assert client.get("/todos", headers=headers_b).status_code == 200
 
 
 def test_bucket_resets_on_refill() -> None:
     headers = _make_user()
-    for _ in range(60):
-        client.get("/todos", headers=headers)
-    assert client.get("/todos", headers=headers).status_code == 429
+    with patch.object(rate_limit.TokenBucket, "consume", _frozen_consume()):
+        for _ in range(60):
+            client.get("/todos", headers=headers)
+        assert client.get("/todos", headers=headers).status_code == 429
 
     mono = [0.0]
     original_consume = rate_limit.TokenBucket.consume


### PR DESCRIPTION
## Summary

- **Storage engine swap**: Replaced `aiosqlite` (SQLite) with `asyncpg` (PostgreSQL) across the entire codebase — `db.py`, `app.py`, `auth.py`
- **SQL dialect migration**: All queries updated to Postgres syntax — `$N` placeholders, `BIGSERIAL`, native `BOOLEAN`, `TIMESTAMPTZ`, `RETURNING` clauses, `ON CONFLICT DO NOTHING`, `COUNT(*) FILTER (WHERE done)`, `LOWER()` for case-insensitive email/tag lookups
- **Connection pooling**: Event-loop-aware pool management via `asyncpg.create_pool()` with `min_size=1, max_size=10`, replacing per-request SQLite connections
- **CI service container**: Added `postgres:16-alpine` service to `.github/workflows/test.yml` with health checks and `DATABASE_URL` env var
- **Test isolation**: Replaced SQLite `tmp_path` fixture with `TRUNCATE ... RESTART IDENTITY CASCADE` pattern for per-test Postgres isolation
- **Dependency swap**: `asyncpg>=0.29` replaces `aiosqlite>=0.19` in `pyproject.toml`

## Test plan

- [x] All 109 tests pass locally against PostgreSQL 16
- [x] `grep -E "sqlite|aiosqlite" src/todo_api/` returns zero matches
- [x] `grep -E "asyncpg" pyproject.toml` is present; `grep -E "aiosqlite" pyproject.toml` is absent
- [ ] CI `Tests / pytest` check passes with Postgres service container

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)